### PR TITLE
Fix UWP project references

### DIFF
--- a/TSS.NET/Samples/Simulator/Simulator.csproj
+++ b/TSS.NET/Samples/Simulator/Simulator.csproj
@@ -4,6 +4,6 @@
   </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/TSS.NET/TSS.Net.UWP/BCryptInterface.cs
+++ b/TSS.NET/TSS.Net.UWP/BCryptInterface.cs
@@ -1,0 +1,1391 @@
+﻿/* 
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
+
+using Interop = System.Runtime.InteropServices;
+
+namespace Tpm2Lib
+{
+
+    public abstract class BCryptObject
+    {
+        internal protected UIntPtr Handle = UIntPtr.Zero;
+
+        public int LastError = 0;
+
+        public BCryptObject() { }
+
+        public BCryptObject(UIntPtr keyHandle)
+        {
+            Handle = keyHandle;
+        }
+
+        public static implicit operator UIntPtr (BCryptObject key)
+        {
+            return key.Handle;
+        }
+
+        /// <summary>
+        /// Obtain the value of an NCrypt property from the platform provider.
+        /// </summary>
+        /// <param name="property">The name of the property.</param>
+        /// <returns>Byte array containing the property value or null.</returns>
+        public byte[] GetPropertyBytes(string propName)
+        {
+            uint propSize = 0;
+            LastError = Native.BCryptGetProperty(Handle, propName, null, 0, out propSize, 0);
+            if (LastError == 0)
+            {
+                var propValue = new byte[propSize];
+                LastError = Native.BCryptGetProperty(Handle, propName, propValue, propSize, out propSize, 0);
+                if (LastError == 0)
+                {
+                    return propValue;
+                }
+            }
+            return null;
+        }
+
+        public uint GetProperty(string propName)
+        {
+            byte[] prop = GetPropertyBytes(propName);
+            if (prop == null)
+                return 0;
+            Debug.Assert(prop.Length == 4);
+            return (((uint)prop[3] & 0xff) << 24) +
+                   (((uint)prop[2] & 0xff) << 16) +
+                   (((uint)prop[1] & 0xff) << 8) +
+                   ((uint)prop[0] & 0xff);
+        }
+
+        public void SetProperty(string propName, byte[] value)
+        {
+            LastError = Native.BCryptSetProperty(Handle, propName, value, (uint)value.Length, 0);
+        }
+
+        public void SetProperty(string propName, string value)
+        {
+            SetProperty(propName, Globs.BytesFromString(value));
+        }
+
+        public void SetProperty(string propName, uint value)
+        {
+            var buf = new byte[sizeof(uint)];
+            buf[3] = (byte)((value >> 24) & 0xff);
+            buf[2] = (byte)((value >> 16) & 0xff);
+            buf[1] = (byte)((value >> 8) & 0xff);
+            buf[0] = (byte)(value & 0xff);
+            SetProperty(propName, buf);
+        }
+    } // class BCryptObject
+
+    public class BCryptKey : BCryptObject, IDisposable
+    {
+        public BCryptKey(UIntPtr keyHandle)
+            : base(keyHandle)
+        {
+        }
+
+        public static implicit operator BCryptKey(UIntPtr keyHandle)
+        {
+            return new BCryptKey(keyHandle);
+        }
+
+        ~BCryptKey()
+        {
+            Dispose();
+        }
+
+        public void Dispose()
+        {
+            Destroy();
+        }
+
+        /// <summary>
+        /// Free all native resources.
+        /// </summary>
+        public void Destroy()
+        {
+            if (Handle != UIntPtr.Zero)
+            {
+                LastError = Native.BCryptDestroyKey(Handle);
+                Handle = UIntPtr.Zero;
+            }
+        }
+
+        public byte[] Export(string blobType)
+        {
+            var blobSize = UIntPtr.Zero;
+            LastError = Native.BCryptExportKey(Handle, UIntPtr.Zero, blobType,
+                                               null, 0, out blobSize, 0);
+            if (LastError == 0)
+            {
+                uint blobCapacity = (uint)blobSize;
+                var keyBlob = new byte[blobCapacity];
+                LastError = Native.BCryptExportKey(Handle, UIntPtr.Zero, blobType,
+                                                   keyBlob, (uint)blobSize, out blobSize, 0);
+                if (LastError == 0)
+                {
+                    Debug.Assert(blobCapacity == (uint)blobSize);
+                    return keyBlob;
+                }
+            }
+            return null;
+        }
+
+        public byte[] ExportSymKey(UIntPtr keyHandle)
+        {
+            byte[] keyBlob = Export(Native.BCRYPT_KEY_DATA_BLOB);
+
+            // 12 is sizeof(BCRYPT_KEY_DATA_BLOB_HEADER)
+            if (keyBlob != null && keyBlob.Length > 12)
+            {
+                uint keySize = GetProperty(Native.BCRYPT_KEY_LENGTH) / 8;
+                uint exportedKeySize = BitConverter.ToUInt32(keyBlob, 8);
+                if (keyBlob.Length == 12 + keySize && keySize == exportedKeySize)
+                {
+                    return Globs.CopyData(keyBlob, 12);
+                }
+            }
+            Globs.Throw("ExportSymKey(): " + (keyBlob != null ? "Invalid" : "No") + " symmetric key blob returned");
+            return null;
+        }
+
+        public byte[] Encrypt(byte[] input, BCryptOaepPaddingInfo paddingInfo = null,
+                              byte[] iv = null, uint flags = 0)
+        {
+            IntPtr padding = IntPtr.Zero;
+            if (paddingInfo != null)
+            {
+                padding = Marshal.AllocHGlobal(Marshal.SizeOf(paddingInfo));
+                Marshal.StructureToPtr(paddingInfo, padding, false);
+                flags |= Native.BCRYPT_PAD_OAEP;
+            }
+
+            uint ivSize = 0;
+            if (iv != null)
+            {
+                if (iv.Length == 0)
+                {
+                    iv = null;
+                }
+                else
+                {
+                    uint blockLen = GetProperty(Native.BCRYPT_BLOCK_LENGTH);
+                    if (blockLen == 0)
+                        return null;    // unsupported block cypher mode
+                    Debug.Assert(blockLen > 0);
+                    if (blockLen != iv.Length)
+                    {
+                        Globs.Throw<ArgumentException>("Encrypt(): Invalid IV size " + iv.Length);
+                        return null;
+                    }
+                    // BCRYPT_BLOCK_PADDING causes gratuitous padding for block-aligned data buffers
+                    //flags |= BCRYPT_BLOCK_PADDING;
+                    ivSize = (uint)iv.Length;
+                }
+            }
+            uint bytesReturned;
+            LastError = Native.BCryptEncrypt(Handle, input, (uint)input.Length,
+                                             padding, iv, ivSize,
+                                             null, 0, out bytesReturned, flags);
+
+            byte[] outBuf = null;
+            if (LastError == 0)
+            {
+                outBuf = new byte[bytesReturned];
+                LastError = Native.BCryptEncrypt(Handle, input, (uint)input.Length,
+                                                 padding, iv, ivSize,
+                                                 outBuf, bytesReturned, out bytesReturned, flags);
+            }
+            Marshal.FreeHGlobal(padding);
+            return outBuf;
+        }
+
+        public byte[] Decrypt(byte[] input, BCryptOaepPaddingInfo paddingInfo = null,
+                              byte[] iv = null, uint flags = 0)
+        {
+            IntPtr padding = IntPtr.Zero;
+            if (paddingInfo != null)
+            {
+                padding = Marshal.AllocHGlobal(Marshal.SizeOf(paddingInfo));
+                Marshal.StructureToPtr(paddingInfo, padding, false);
+                flags |= Native.BCRYPT_PAD_OAEP;
+            }
+
+            uint ivSize = 0;
+            if (iv != null)
+            {
+                if (iv.Length == 0)
+                {
+                    iv = null;
+                }
+                else
+                {
+                    uint blockLen = GetProperty(Native.BCRYPT_BLOCK_LENGTH);
+                    Debug.Assert(blockLen > 0);
+                    if (blockLen != iv.Length)
+                    {
+                        Globs.Throw<ArgumentException>("Encrypt(): Invalid IV size ("
+                                        + iv.Length + " instead of " + blockLen + ")");
+                        return null;
+                    }
+                    // BCRYPT_BLOCK_PADDING causes gratuitous padding for block-aligned data buffers
+                    //flags |= Native.BCRYPT_BLOCK_PADDING;
+                    ivSize = (uint)iv.Length;
+                }
+            }
+
+            uint bytesReturned;
+            LastError = Native.BCryptDecrypt(Handle, input, (uint)input.Length,
+                                             padding, iv, ivSize,
+                                             null, 0, out bytesReturned, flags);
+
+            byte[] outBuf = null;
+            if (LastError == 0)
+            {
+                outBuf = new byte[bytesReturned];
+                LastError = Native.BCryptDecrypt(Handle, input, (uint)input.Length,
+                                                 padding, iv, ivSize,
+                                                 outBuf, bytesReturned, out bytesReturned, flags);
+            }
+            Marshal.FreeHGlobal(padding);
+            return outBuf;
+        }
+
+        public byte[] SignHash(byte[] digest, BcryptScheme scheme, TpmAlgId schemeHash = TpmAlgId.None)
+        {
+            uint flags = 0;
+            IntPtr padding = IntPtr.Zero;
+            if (schemeHash != TpmAlgId.None)
+            {
+                if (scheme == BcryptScheme.Rsassa)
+                {
+                    var paddingInfo = new BCryptPkcs1PaddingInfo(schemeHash);
+                    padding = Marshal.AllocHGlobal(Marshal.SizeOf(paddingInfo));
+                    Marshal.StructureToPtr(paddingInfo, padding, false);
+                    flags |= Native.BCRYPT_PAD_PKCS1;
+                }
+                else if (scheme == BcryptScheme.Pss)
+                {
+                    var paddingInfo = new BCryptPssPaddingInfo(schemeHash, 0);
+                    padding = Marshal.AllocHGlobal(Marshal.SizeOf(paddingInfo));
+                    Marshal.StructureToPtr(paddingInfo, padding, false);
+                    flags |= Native.BCRYPT_PAD_PSS;
+                }
+                else //if (scheme == BcryptScheme.Ecdsa)
+                {
+                    padding = IntPtr.Zero;
+                }
+            }
+
+            uint bytesReturned;
+            LastError = Native.BCryptSignHash(Handle, padding, digest, (uint)digest.Length,
+                                              null, 0, out bytesReturned, flags);
+
+            byte[] outBuf = null;
+            if (LastError == 0)
+            {
+                outBuf = new byte[bytesReturned];
+                LastError = Native.BCryptSignHash(Handle, padding, digest, (uint)digest.Length,
+                                                  outBuf, bytesReturned, out bytesReturned, flags);
+
+            }
+            Marshal.FreeHGlobal(padding);
+            return LastError == 0 ? outBuf : null;
+        }
+
+        public bool VerifySignature(byte[] digest, byte[] signature,
+                                    TpmAlgId schemeHash = TpmAlgId.None, bool Rsassa = true)
+        {
+            uint flags = 0;
+            IntPtr padding = IntPtr.Zero;
+            if (schemeHash != TpmAlgId.None)
+            {
+                if (Rsassa)
+                {
+                    var paddingInfo = new BCryptPkcs1PaddingInfo(schemeHash);
+                    padding = Marshal.AllocHGlobal(Marshal.SizeOf(paddingInfo));
+                    Marshal.StructureToPtr(paddingInfo, padding, false);
+                    flags |= Native.BCRYPT_PAD_PKCS1;
+                }
+                else
+                {
+                    var paddingInfo = new BCryptPssPaddingInfo(schemeHash, 0);
+                    padding = Marshal.AllocHGlobal(Marshal.SizeOf(paddingInfo));
+                    Marshal.StructureToPtr(paddingInfo, padding, false);
+                    flags |= Native.BCRYPT_PAD_PSS;
+                }
+            }
+
+            LastError = Native.BCryptVerifySignature(Handle, padding, digest, (uint)digest.Length,
+                                                     signature, (uint)signature.Length, flags);
+            Marshal.FreeHGlobal(padding);
+            return LastError == 0;
+        }
+
+        public byte[] DeriveKey(BCryptKey pubKey, TpmAlgId hashAlg, byte[] secretPrepend, byte[] secretAppend)
+        {
+            UIntPtr secretHandle;
+            LastError = Native.BCryptSecretAgreement(Handle, pubKey, out secretHandle, 0);
+            if (LastError != 0)
+            {
+                return null;
+            }
+
+            var hashAlgName = Globs.BytesFromString(Native.BCryptHashAlgName(hashAlg));
+
+#if false
+            var bufferDesc = new byte[0];   // BCryptBufferDesc
+            var buffers = new byte[0];      // BCryptBuffer[]
+            int offset = 0;
+
+            WriteToBuffer(ref bufferDesc, ref offset, KDF_HASH_ALGORITHM);
+            Marshal.StringToHGlobalUni();
+
+            offset = 0;
+            WriteToBuffer(ref bufferDesc, ref offset, BCRYPTBUFFER_VERSION);
+            WriteToBuffer(ref bufferDesc, ref offset, 3);    // number of parameter buffers
+            WriteToBuffer(ref bufferDesc, ref offset, KDF_HASH_ALGORITHM);
+
+            IntPtr paramListPtr = Marshal.AllocHGlobal(bufferDesc.Length);
+            Marshal.Copy(bufferDesc, 0, paramListPtr, bufferDesc.Length);
+#endif
+            var buffers = new BCryptBuffer[] {
+                    new BCryptBuffer(hashAlgName.Length, Native.KDF_HASH_ALGORITHM, hashAlgName),
+                    new BCryptBuffer(secretPrepend.Length, Native.KDF_SECRET_PREPEND, secretPrepend),
+                    new BCryptBuffer(secretAppend.Length, Native.KDF_SECRET_APPEND, secretAppend)
+                };
+            var bufDesc = new BCryptBufferDesc(Native.BCRYPTBUFFER_VERSION, 3, buffers);
+
+            IntPtr paramListPtr = Marshal.AllocHGlobal(Marshal.SizeOf(bufDesc));
+            Marshal.StructureToPtr(bufDesc, paramListPtr, false);
+
+            byte[] derivedKey = null;
+            uint derivedKeySize = 0;
+            LastError = Native.BCryptDeriveKey(secretHandle, Native.BCRYPT_KDF_HASH, paramListPtr,
+                                               null, 0, out derivedKeySize, 0);
+            if (LastError == 0)
+            {
+                derivedKey = new byte[derivedKeySize];
+                LastError = Native.BCryptDeriveKey(secretHandle, Native.BCRYPT_KDF_HASH, paramListPtr,
+                                                   derivedKey, derivedKeySize, out derivedKeySize, 0);
+                if (LastError != 0)
+                {
+                    derivedKey = null;
+                }
+            }
+
+            Native.BCryptDestroySecret(secretHandle);
+            Marshal.FreeHGlobal(paramListPtr);
+            return derivedKey;
+        }
+    } // class BCryptKey
+
+    internal class BCryptAlgorithm : BCryptObject, IDisposable
+    {
+        private UIntPtr HashHandle = UIntPtr.Zero;
+        private uint DigestSize = 0;
+
+        public BCryptAlgorithm(string algName, uint flags = 0)
+        {
+            Open(algName, flags);
+        }
+
+        public void Open(string algName, uint flags = 0)
+        {
+            if (Handle != UIntPtr.Zero)
+            {
+                Globs.Throw("BCryptInterface.Open(): Already opened.");
+                return;
+            }
+            LastError = Native.BCryptOpenAlgorithmProvider(out Handle, algName,
+                                                           Native.MS_PRIMITIVE_PROVIDER, flags);
+        }
+
+        public void Close()
+        {
+            if (Handle != UIntPtr.Zero)
+            {
+                if (HashHandle != UIntPtr.Zero)
+                {
+                    Native.BCryptDestroyHash(HashHandle);
+                    HashHandle = UIntPtr.Zero;
+                }
+                LastError = Native.BCryptCloseAlgorithmProvider(Handle, 0);
+                Handle = UIntPtr.Zero;
+            }
+            else
+            {
+                Debug.Assert(HashHandle == UIntPtr.Zero);
+                LastError = 0;
+            }
+        }
+
+        public void Dispose()
+        {
+            Close();
+        }
+
+        ~BCryptAlgorithm()
+        {
+            Dispose();
+        }
+
+        public BCryptKey ImportKey(String blobType, byte[] keyBlob)
+        {
+            UIntPtr keyHandle = UIntPtr.Zero;
+            LastError = Native.BCryptImportKey(Handle, UIntPtr.Zero, blobType,
+                                                      out keyHandle, UIntPtr.Zero, 0,
+                                                      keyBlob, (uint)keyBlob.Length, 0);
+            return keyHandle;
+        }
+
+        public BCryptKey GenerateKeyPair(uint keyLen)
+        {
+            UIntPtr keyHandle;
+            LastError = Native.BCryptGenerateKeyPair(Handle, out keyHandle, keyLen, 0);
+            if (LastError == 0)
+            {
+                LastError = Native.BCryptFinalizeKeyPair(keyHandle, 0);
+                if (LastError == 0)
+                {
+                    return keyHandle;
+                }
+                Native.BCryptDestroyKey(keyHandle);
+            }
+            return UIntPtr.Zero;
+        }
+
+        /// <summary>
+        /// Import a key pair into the BCrypt library.
+        /// </summary>
+        /// <returns>An object encapsulating a handle to the imported key.</returns>
+        public BCryptKey ImportKeyPair(String blobType, byte[] keyBlob)
+        {
+            UIntPtr keyHandle = UIntPtr.Zero;
+            LastError = Native.BCryptImportKeyPair(Handle, UIntPtr.Zero, blobType,
+                                                          out keyHandle, keyBlob, (uint)keyBlob.Length, 0);
+            return keyHandle;
+        }
+
+        private static void WriteToBuffer(ref byte[] buffer, ref int offset, uint value)
+        {
+            buffer[offset + 3] = (byte)((value >> 24) & 0xff);
+            buffer[offset + 2] = (byte)((value >> 16) & 0xff);
+            buffer[offset + 1] = (byte)((value >> 8) & 0xff);
+            buffer[offset + 0] = (byte)(value & 0xff);
+            offset += 4;
+        }
+
+        private static void WriteToBuffer(ref byte[] buffer, ref int offset, byte[] value)
+        {
+            if (value.Length <= buffer.Length - offset)
+            {
+                Array.Copy(value, 0, buffer, offset, value.Length);
+                offset += value.Length;
+            }
+        }
+
+        /// <summary>
+        /// Load an RSA key into the BCrypt provider. This method creates the necessary data structures and
+        /// calls the BCrypt APIs required to create a RSA key.
+        /// </summary>
+        /// <param name="exponent">The key's exponent.</param>
+        /// <param name="modulus">The key's modulus.</param>
+        /// <param name="prime1">The key's first prime number.</param>
+        /// <param name="prime2">The key's second prime number.</param>
+        /// <returns>An object encapsulating a handle to the loaded key.</returns>
+        public BCryptKey LoadRSAKey(byte[] exponent, byte[] modulus,
+                                    byte[] prime1 = null, byte[] prime2 = null)
+        {
+            uint primeLen1 = 0,
+                 primeLen2 = 0;
+            // Compute the size of BCRYPT_RSAKEY_BLOB
+            int rsaKeySize = exponent.Length + modulus.Length + 24;
+            if (prime1 != null && prime1.Length > 0)
+            {
+                if (prime2 == null || prime2.Length == 0)
+                {
+                    Globs.Throw<ArgumentException>("LoadRSAKey(): The second prime is missing");
+                    return UIntPtr.Zero;
+                }
+                primeLen1 = (uint)prime1.Length;
+                primeLen2 = (uint)prime2.Length;
+                rsaKeySize += prime1.Length + prime2.Length;
+            }
+            else if (prime2 != null && prime2.Length > 0)
+            {
+                Globs.Throw<ArgumentException>("LoadRSAKey(): The first prime is missing");
+                return UIntPtr.Zero;
+            }
+
+            var rsaKey = new byte[rsaKeySize];
+
+            // Initialize BCRYPT_RSAKEY_BLOB
+            int offset = 0;
+            WriteToBuffer(ref rsaKey, ref offset, primeLen1 == 0 ?
+                            Native.BCRYPT_RSAPUBLIC_MAGIC : Native.BCRYPT_RSAPRIVATE_MAGIC);
+            WriteToBuffer(ref rsaKey, ref offset, (uint)modulus.Length * 8);
+            WriteToBuffer(ref rsaKey, ref offset, (uint)exponent.Length);
+            WriteToBuffer(ref rsaKey, ref offset, (uint)modulus.Length);
+            WriteToBuffer(ref rsaKey, ref offset, primeLen1);
+            WriteToBuffer(ref rsaKey, ref offset, primeLen1);
+            WriteToBuffer(ref rsaKey, ref offset, exponent);
+            WriteToBuffer(ref rsaKey, ref offset, modulus);
+            if (primeLen1 != 0)
+            {
+                WriteToBuffer(ref rsaKey, ref offset, prime1);
+                WriteToBuffer(ref rsaKey, ref offset, prime2);
+            }
+
+            return ImportKeyPair(primeLen1 == 0 ? Native.BCRYPT_RSAPUBLIC_BLOB
+                                                : Native.BCRYPT_RSAPRIVATE_BLOB, rsaKey);
+        }
+
+        /// <summary>
+        /// Load a symmetric key into the BCrypt provider.
+        /// </summary>
+        /// <param name="keyData">Key bits.</param>
+        /// <param name="symDef">Key params.</param>
+        /// <param name="blockSize">Block size for CFB mode.</param>
+        /// <returns>An object encapsulating a handle to the loaded key.</returns>
+        public BCryptKey LoadSymKey(byte[] keyData, SymDefObject symDef, int blockSize = 0)
+        {
+            string modeName = Native.BCryptChainingMode(symDef.Mode);
+            if (string.IsNullOrEmpty(modeName))
+            {
+                Globs.Throw<ArgumentException>("LoadSymKey(): Unsupported chaining mode " + symDef.Mode);
+                return UIntPtr.Zero;
+            }
+
+            // Create key blob for import
+            // 12 is sizeof(BCRYPT_KEY_DATA_BLOB_HEADER)
+            var keyBlob = new byte[12 + keyData.Length];
+            int offset = 0;
+            WriteToBuffer(ref keyBlob, ref offset, Native.BCRYPT_KEY_DATA_BLOB_MAGIC);
+            WriteToBuffer(ref keyBlob, ref offset, Native.BCRYPT_KEY_DATA_BLOB_VERSION1);
+            WriteToBuffer(ref keyBlob, ref offset, (uint)keyData.Length);
+            WriteToBuffer(ref keyBlob, ref offset, keyData);
+
+            uint blockSizeAlg = GetProperty(Native.BCRYPT_BLOCK_LENGTH);
+            if (blockSize != 0 && blockSize != blockSizeAlg)
+            {
+                SetProperty(Native.BCRYPT_BLOCK_LENGTH, (uint)blockSize);
+                blockSizeAlg = GetProperty(Native.BCRYPT_BLOCK_LENGTH);
+            }
+            //  Import symmetric key
+            var key = ImportKey(Native.BCRYPT_KEY_DATA_BLOB, keyBlob);
+            key.SetProperty(Native.BCRYPT_CHAINING_MODE, modeName);
+            uint blockSizeKey = key.GetProperty(Native.BCRYPT_BLOCK_LENGTH);
+            Debug.Assert(blockSizeAlg == blockSizeKey);
+            uint KeyLen = key.GetProperty(Native.BCRYPT_KEY_LENGTH);
+            Debug.Assert(KeyLen == symDef.KeyBits);
+            if (symDef.Mode == TpmAlgId.Cfb)
+            {
+                key.SetProperty(Native.BCRYPT_MESSAGE_BLOCK_LENGTH, (uint)blockSize);
+            }
+            Debug.Assert(key.GetProperty(Native.BCRYPT_MESSAGE_BLOCK_LENGTH) == blockSizeKey);
+            return key;
+        }
+
+        public BCryptKey GenerateSymKey(SymDefObject symDef, byte[] keyData = null, int blockSize = 0)
+        {
+            string modeName = Native.BCryptChainingMode(symDef.Mode);
+            if (string.IsNullOrEmpty(modeName))
+            {
+                Globs.Throw<ArgumentException>("GenerateSymKey(): Unsupported chaining mode " + symDef.Mode);
+                return null;
+            }
+            UIntPtr keyHandle = UIntPtr.Zero;
+            int keySize = symDef.KeyBits / 8;
+            //SetProperty(BCRYPT_KEY_LENGTH, symDef.KeyBits);   // not supported
+            SetProperty(Native.BCRYPT_CHAINING_MODE, modeName);
+            uint blockSizeAlg = GetProperty(Native.BCRYPT_BLOCK_LENGTH);
+            if (blockSize != 0 && blockSize != blockSizeAlg)
+            {
+                SetProperty(Native.BCRYPT_BLOCK_LENGTH, (uint)blockSize);
+                blockSizeAlg = GetProperty(Native.BCRYPT_BLOCK_LENGTH);
+            }
+            if (keyData != null && keyData.Length != keySize)
+            {
+                Globs.Throw<ArgumentException>("GenerateSymKey(): Invalid key length");
+                return UIntPtr.Zero;
+            }
+            LastError = Native.BCryptGenerateSymmetricKey(Handle, out keyHandle, UIntPtr.Zero, 0,
+                                                          keyData ?? Globs.GetRandomBytes(keySize),
+                                                          (uint)keySize, 0);
+            if (LastError != 0)
+                return null;
+            BCryptKey key = keyHandle;
+            key.SetProperty(Native.BCRYPT_CHAINING_MODE, modeName);
+            uint blockSizeKey = key.GetProperty(Native.BCRYPT_BLOCK_LENGTH);
+            Debug.Assert(blockSizeAlg == blockSizeKey);
+            uint KeyLen = key.GetProperty(Native.BCRYPT_KEY_LENGTH);
+            Debug.Assert(KeyLen == symDef.KeyBits);
+            if (symDef.Mode == TpmAlgId.Cfb)
+            {
+                key.SetProperty(Native.BCRYPT_MESSAGE_BLOCK_LENGTH, (uint)blockSize);
+            }
+            Debug.Assert(key.GetProperty(Native.BCRYPT_MESSAGE_BLOCK_LENGTH) == blockSizeKey);
+            return key;
+        }
+
+        public byte[] HashData(byte[] data)
+        {
+            if (HashHandle == UIntPtr.Zero)
+            {
+                LastError = Native.BCryptCreateHash(Handle, out HashHandle,
+                                                    UIntPtr.Zero, 0, null, 0,
+                                                    Native.BCRYPT_HASH_REUSABLE_FLAG);
+                if (LastError != 0)
+                {
+                    Debug.Assert(HashHandle == UIntPtr.Zero);
+                    return null;
+                }
+                DigestSize = GetProperty(Native.BCRYPT_HASH_LENGTH);
+            }
+            LastError = Native.BCryptHashData(HashHandle, data, (uint)data.Length, 0);
+            if (LastError != 0)
+            {
+                return null;
+            }
+
+            var digest = new byte[DigestSize];
+            LastError = Native.BCryptFinishHash(HashHandle, digest, DigestSize, 0);
+            if (LastError != 0)
+            {
+                return null;
+            }
+            return digest;
+        }
+
+        public byte[] HmacData(byte[] key, byte[] data)
+        {
+            if (HashHandle == UIntPtr.Zero)
+            {
+                LastError = Native.BCryptCreateHash(Handle, out HashHandle,
+                                                    UIntPtr.Zero, 0,
+                                                    key, (uint)key.Length,
+                                                    Native.BCRYPT_HASH_REUSABLE_FLAG);
+                if (LastError != 0)
+                {
+                    Debug.Assert(HashHandle == UIntPtr.Zero);
+                    return null;
+                }
+                DigestSize = GetProperty(Native.BCRYPT_HASH_LENGTH);
+            }
+            LastError = Native.BCryptHashData(HashHandle, data, (uint)data.Length, 0);
+            if (LastError != 0)
+            {
+                return null;
+            }
+
+            var digest = new byte[DigestSize];
+            LastError = Native.BCryptFinishHash(HashHandle, digest, DigestSize, 0);
+            if (LastError != 0)
+            {
+                return null;
+            }
+            return digest;
+        }
+
+    } // class BCryptAlgorithm
+
+    public partial class Native
+    {
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptOpenAlgorithmProvider(
+            out UIntPtr AlgProvider,
+            [Interop.MarshalAs(UnmanagedType.LPWStr), In]
+                 String AlgId,
+            [Interop.MarshalAs(UnmanagedType.LPWStr), In]
+                 String Implementation,
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptCloseAlgorithmProvider(
+            UIntPtr AlgProvider,
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptGetProperty(
+            UIntPtr ObjectHandle,
+            [Interop.MarshalAs(UnmanagedType.LPWStr), In]
+                 String Property,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3), Out]
+                 byte[] Buffer,
+            uint BufferSize,
+            out uint ResultSize,
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptSetProperty(
+            UIntPtr ObjectHandle,
+            [Interop.MarshalAs(UnmanagedType.LPWStr), In]
+                 String Property,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3), In]
+                 byte[] Buffer,
+            uint BufferSize,
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptCreateHash(
+            // _Inout_  BCRYPT_ALG_HANDLE hAlgorithm,
+            UIntPtr AlgProvider,
+            // _Out_    BCRYPT_HASH_HANDLE *phHash,
+            out UIntPtr HashHandle,
+            // _Out_    PUCHAR pbHashObject,
+            UIntPtr HashObject,     // Must be UIntPtr.Zero
+            // _In_opt_ ULONG cbHashObject,
+            uint HashObjectSize,  // Must be 0
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5), In]
+                byte[] Secret,
+            // _In_     ULONG cbSecret,
+            uint SecretSize,      // Must be 0
+            // _In_     ULONG dwFlags
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptHashData(
+            // _Inout_  BCRYPT_HASH_HANDLE hHash,
+            UIntPtr HashHandle,
+            // _In_     PUCHAR pbInput,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2), In]
+                 byte[] DataBuffer,
+            // _In_     ULONG cbInput,
+            uint BufferSize,
+            // _In_     ULONG dwFlags
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptFinishHash(
+            // _Inout_  BCRYPT_HASH_HANDLE hHash,
+            UIntPtr HashHandle,
+            // _Out_    PUCHAR pbOutput,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2), Out]
+                byte[] Digest,
+            // _In_     ULONG cbOutput,
+            uint DigestSize,
+            // _In_     ULONG dwFlags
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptDestroyHash(
+            // _Inout_  BCRYPT_HASH_HANDLE hHash,
+            UIntPtr HashHandle);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptImportKey(
+            UIntPtr AlgProvider,
+            UIntPtr ImportKeyHandle,
+            [Interop.MarshalAs(UnmanagedType.LPWStr), In]
+                 String BlobType,
+            out UIntPtr KeyHandle,
+            UIntPtr KeyObject,      // must be UIntPtr.Zero
+            uint KeyObjectSize,   // must be 0
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 7), In]
+                 byte[] Input,
+            uint InputSize,
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+        BCryptGenerateKeyPair(
+            // _Inout_  BCRYPT_ALG_HANDLE hAlgorithm,
+            UIntPtr AlgProvider,
+            // _Out_    BCRYPT_KEY_HANDLE *phKey,
+            out UIntPtr KeyHandle,
+            // _In_     ULONG dwLength,
+            uint KeyLength,
+            // _In_     ULONG dwFlags
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptFinalizeKeyPair(
+            // _Inout_  BCRYPT_KEY_HANDLE hKey,
+            UIntPtr KeyHandle,
+            // _In_     ULONG dwFlags
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptGenerateSymmetricKey(
+            // _Inout_    BCRYPT_ALG_HANDLE hAlgorithm,
+            UIntPtr AlgProvider,
+            // _Out_      BCRYPT_KEY_HANDLE *phKey,
+            out UIntPtr KeyHandle,
+            // _Out_opt_  PUCHAR pbKeyObject,
+            UIntPtr KeyObject,      // must be UIntPtr.Zero
+            // _In_       ULONG cbKeyObject,
+            uint KeyObjectSize,   // must be 0
+            // _In_       PUCHAR pbSecret,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5), In]
+                 byte[] Secret,
+            // _In_       ULONG cbSecret,
+            uint SecretSize,
+            // _In_       ULONG dwFlags
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptExportKey(
+            UIntPtr Key,
+            UIntPtr WrapperKey, // must be NULL on Vista & WinSvr2008
+            [Interop.MarshalAs(UnmanagedType.LPWStr), In]
+                 String BlobType,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5), Out]
+                byte[] Output,
+            uint OutputCapacity,
+            out UIntPtr OutputSize,
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptImportKeyPair(
+            UIntPtr AlgProvider,
+            UIntPtr WrapperKey, // must be NULL on Vista & WinSvr2008
+            [Interop.MarshalAs(UnmanagedType.LPWStr), In]
+                 String BlobType,
+            out UIntPtr KeyHandle,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5), In]
+                 byte[] Input,
+            uint InputSize,
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptDestroyKey(
+            UIntPtr Key);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptEncrypt(
+            UIntPtr Key,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2), In]
+                 byte[] Input,
+            uint InputSize,
+            IntPtr PaddingInfo,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5), In, Out]
+                 byte[] IV,
+            uint IVSize,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 7), Out]
+                 byte[] Output,
+            uint OutputSize,
+            out uint ResultOuputSize,
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptDecrypt(
+            UIntPtr Key,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2), In]
+                 byte[] Input,
+            uint InputSize,
+            IntPtr PaddingInfo,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5), In, Out]
+                 byte[] IV,
+            uint IVSize,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 7), Out]
+                 byte[] Output,
+            uint OutputCapacity,
+            out uint ResultOuputSize,
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptSignHash(
+            // _In_      BCRYPT_KEY_HANDLE hKey,
+            UIntPtr KeyHandle,
+            // _In_opt_  VOID *pPaddingInfo,
+            IntPtr PaddingInfo,
+            // _In_      PBYTE pbInput,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3), In]
+                 byte[] Input,
+            // _In_      DWORD cbInput,
+            uint InputSize,
+            // _Out_     PBYTE pbOutput,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5), Out]
+                 byte[] Output,
+            // _In_      DWORD cbOutput,
+            uint OutputCapacity,
+            // _Out_     DWORD *pcbResult,
+            out uint ResultOuputSize,
+            // _In_      ULONG dwFlags
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptVerifySignature(
+            // _In_      BCRYPT_KEY_HANDLE hKey,
+            UIntPtr KeyHandle,
+            // _In_opt_  VOID *pPaddingInfo,
+            IntPtr PaddingInfo,
+            // _In_      PUCHAR pbHash,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3), In]
+                 byte[] Digest,
+            // _In_      ULONG cbHash,
+            uint DigestSize,
+            // _In_      PUCHAR pbSignature,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 5), In]
+                 byte[] Signature,
+            // _In_      ULONG cbSignature,
+            uint SignatureSize,
+            // _In_      ULONG dwFlags
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptSecretAgreement(
+            // _In_   BCRYPT_KEY_HANDLE hPrivKey,
+            UIntPtr PrivKeyHandle,
+            // _In_   BCRYPT_KEY_HANDLE hPubKey,
+            UIntPtr PubKeyHandle,
+            // _Out_  BCRYPT_SECRET_HANDLE *phSecret,
+            out UIntPtr SecretHandle,
+            // _In_   ULONG dwFlags
+            uint Flags);
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptDestroySecret(
+            // _In_  BCRYPT_SECRET_HANDLE hSecret
+            UIntPtr SecretHandle
+        );
+
+        [DllImport("bcrypt.dll", CharSet = CharSet.Unicode)]
+        internal static extern int
+            BCryptDeriveKey(
+            // _In_       BCRYPT_SECRET_HANDLE hSharedSecret,
+            UIntPtr SecretHandle,
+            // _In_       LPCWSTR pwszKDF,
+            [Interop.MarshalAs(UnmanagedType.LPWStr), In]
+                 String KDF,
+            // _In_opt_   BCryptBufferDesc *pParameterList,
+            IntPtr ParameterList,
+            // _Out_opt_  PUCHAR pbDerivedKey,
+            [Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4), Out]
+                 byte[] DerivedKey,
+            // _In_       ULONG cbDerivedKey,
+            uint DerivedKeyCapacity,
+            // _Out_      ULONG *pcbResult,
+            out uint DerivedKeySize,
+            // _In_       ULONG dwFlags
+            uint Flags);
+
+#if false
+        public static string BCryptAlgName(TpmAlgId algId, EccCurve curveID = EccCurve.None, bool signing = false)
+        {
+            switch (algId)
+            {
+                case TpmAlgId.Rsa:
+                    return BCRYPT_RSA_ALGORITHM;
+                case TpmAlgId.Ecc:
+                    switch (curveID)
+                    {
+                        case EccCurve.NistP256:
+                            return signing ? BCRYPT_ECDSA_P256_ALGORITHM : BCRYPT_ECDH_P256_ALGORITHM;
+                        case EccCurve.NistP384:
+                            return signing ? BCRYPT_ECDSA_P384_ALGORITHM : BCRYPT_ECDH_P384_ALGORITHM;
+                        case EccCurve.NistP521:
+                            return signing ? BCRYPT_ECDSA_P521_ALGORITHM : BCRYPT_ECDH_P521_ALGORITHM;
+                    }
+                    Globs.Throw<ArgumentException>("Unsupported ECC curve");
+                    return null;
+                case TpmAlgId.Aes:
+                    return BCRYPT_AES_ALGORITHM;
+                case TpmAlgId.Sha512:
+                    return BCRYPT_SHA512_ALGORITHM;
+            }
+            Globs.Throw<ArgumentException>("Unsupported algorithm");
+            return null;
+        }
+#endif
+
+        public static string BCryptHashAlgName(TpmAlgId hashAlgId)
+        {
+            switch (hashAlgId)
+            {
+                case TpmAlgId.Sha1:
+                    return BCRYPT_SHA1_ALGORITHM;
+                case TpmAlgId.Sha256:
+                    return BCRYPT_SHA256_ALGORITHM;
+                case TpmAlgId.Sha384:
+                    return BCRYPT_SHA384_ALGORITHM;
+                case TpmAlgId.Sha512:
+                    return BCRYPT_SHA512_ALGORITHM;
+                default:
+                    return null;
+            }
+        }
+
+        public static string BCryptChainingMode(TpmAlgId modeId)
+        {
+            switch (modeId)
+            {
+                case TpmAlgId.Cfb:
+                    return BCRYPT_CHAIN_MODE_CFB;
+                case TpmAlgId.Cbc:
+                    return BCRYPT_CHAIN_MODE_CBC;
+                case TpmAlgId.Ecb:
+                    return BCRYPT_CHAIN_MODE_ECB;
+                default:
+                    return null;
+            }
+            // BCRYPT_CHAIN_MODE_CCM, BCRYPT_CHAIN_MODE_GCM
+        }
+
+        public const string BCRYPT_RNG_ALGORITHM = "RNG";
+        public const string BCRYPT_RSA_ALGORITHM = "RSA";
+        public const string BCRYPT_AES_ALGORITHM = "AES";
+        public const string BCRYPT_AES_CMAC_ALGORITHM = "AES-CMAC";
+        public const string BCRYPT_3DES_ALGORITHM = "3DES";
+        public const string BCRYPT_SHA1_ALGORITHM = "SHA1";
+        public const string BCRYPT_SHA256_ALGORITHM = "SHA256";
+        public const string BCRYPT_SHA384_ALGORITHM = "SHA384";
+        public const string BCRYPT_SHA512_ALGORITHM = "SHA512";
+        public const string BCRYPT_ECDSA_P256_ALGORITHM = "ECDSA_P256";
+        public const string BCRYPT_ECDSA_P384_ALGORITHM = "ECDSA_P384";
+        public const string BCRYPT_ECDSA_P521_ALGORITHM = "ECDSA_P521";
+        public const string BCRYPT_ECDH_P256_ALGORITHM = "ECDH_P256";
+        public const string BCRYPT_ECDH_P384_ALGORITHM = "ECDH_P384";
+        public const string BCRYPT_ECDH_P521_ALGORITHM = "ECDH_P521";
+
+        public const string BCRYPT_KDF_HASH = "HASH";
+
+        public const string BCRYPT_KEY_DATA_BLOB = "KeyDataBlob";
+        //public const string BCRYPT_PUBLIC_KEY_BLOB = "PUBLICBLOB";
+        public const string BCRYPT_RSAPUBLIC_BLOB = "RSAPUBLICBLOB";
+        public const string BCRYPT_RSAPRIVATE_BLOB = "RSAPRIVATEBLOB";
+        public const string BCRYPT_RSAFULLPRIVATE_BLOB = "RSAFULLPRIVATEBLOB";
+        public const string BCRYPT_ECCPUBLIC_BLOB = "ECCPUBLICBLOB";
+        public const string BCRYPT_ECCPRIVATE_BLOB = "ECCPRIVATEBLOB";
+        public const string LEGACY_RSAPRIVATE_BLOB = "CAPIPRIVATEBLOB";
+
+        public const string MS_PRIMITIVE_PROVIDER = "Microsoft Primitive Provider";
+
+        // Generic algorithm properties
+        public const string BCRYPT_OBJECT_LENGTH = "ObjectLength";
+
+        // Hash algorithm properties
+        public const string BCRYPT_HASH_LENGTH = "HashDigestLength";
+
+        // Symmetric algorithm properties
+        public const string BCRYPT_KEY_LENGTH = "KeyLength";            // bits
+        public const string BCRYPT_BLOCK_LENGTH = "BlockLength";        // bytes (algs & keys)
+        public const string BCRYPT_CHAINING_MODE = "ChainingMode";
+        public const string BCRYPT_CHAIN_MODE_CFB = "ChainingModeCFB";
+        public const string BCRYPT_CHAIN_MODE_CBC = "ChainingModeCBC";
+        public const string BCRYPT_CHAIN_MODE_ECB = "ChainingModeECB";
+        //public const string BCRYPT_CHAIN_MODE_CCM = "ChainingModeCCM";
+        //public const string BCRYPT_CHAIN_MODE_GCM = "ChainingModeGCM";
+
+        // Symmetric key properties
+        public const string BCRYPT_MESSAGE_BLOCK_LENGTH = "MessageBlockLength"; // CFB only
+        public const string BCRYPT_INITIALIZATION_VECTOR = "IV";
+
+        public const uint BCRYPT_RSAPUBLIC_MAGIC = 0x31415352;      // RSA1
+        public const uint BCRYPT_RSAPRIVATE_MAGIC = 0x32415352;     // RSA2
+        public const uint BCRYPT_KEY_DATA_BLOB_MAGIC = 0x4d42444b;  //Key Data Blob Magic (KDBM)
+
+        public const uint BCRYPT_HASH_REUSABLE_FLAG = 0x00000020;
+
+        public const uint BCRYPT_KEY_DATA_BLOB_VERSION1 = 1;
+        public const uint BCRYPT_BLOCK_PADDING = 1;
+        public const uint BCRYPT_PAD_PKCS1 = 2;
+        public const uint BCRYPT_PAD_OAEP = 4;
+        public const uint BCRYPT_PAD_PSS = 8;
+
+        public const uint BCRYPTBUFFER_VERSION = 0;
+
+        public const uint KDF_HASH_ALGORITHM = 0x0;
+        public const uint KDF_SECRET_PREPEND = 0x1;
+        public const uint KDF_SECRET_APPEND = 0x2;
+        public const uint KDF_HMAC_KEY = 0x3;
+        public const uint KDF_LABEL = 0xD;
+        public const uint KDF_SALT = 0xF;
+        public const uint KDF_ITERATION_COUNT = 0x10;
+
+        public const uint BCRYPT_ALG_HANDLE_HMAC = 0x00000008;
+
+    } // partial class NativeMethods
+
+    // BCRYPT_RSAKEY_BLOB
+    public class BCryptRsaKeyBlob : TpmStructureBase
+    {
+        [MarshalAs(0)]
+        public uint Magic;
+        [MarshalAs(1)]
+        public uint BitLength;
+        [MarshalAs(2)]
+        public uint cbPublicExp;
+        [MarshalAs(3)]
+        public uint cbModulus;
+        [MarshalAs(4)]
+        public uint cbPrime1;
+        [MarshalAs(5)]
+        public uint cbPrime2;
+    } // struct RsaPubKey
+
+    // BCRYPT_OAEP_PADDING_INFO
+    [StructLayout(LayoutKind.Sequential)]
+    public sealed class BCryptOaepPaddingInfo : IDisposable
+    {
+        [Interop.MarshalAs(UnmanagedType.LPWStr)]
+        string algId;    // IntPtr
+        IntPtr label;    // byte[]
+        uint labelSize;
+
+        public BCryptOaepPaddingInfo(TpmAlgId hashAlg, byte[] _label)
+        {
+            algId = Native.BCryptHashAlgName(hashAlg);
+            var l = RawRsa.GetLabel(_label);
+            label = Marshal.AllocHGlobal(l.Length);
+            Marshal.Copy(l, 0, label, l.Length);
+            labelSize = (uint)l.Length;
+        }
+
+        ~BCryptOaepPaddingInfo()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public void Dispose(bool disposing)
+        {
+            Globs.Free(ref label);
+        }
+    } // class BCryptOaepPaddingInfo
+
+    // BCRYPT_PKCS1_PADDING_INFO
+    [StructLayout(LayoutKind.Sequential)]
+    public class BCryptPkcs1PaddingInfo
+    {
+        [Interop.MarshalAs(UnmanagedType.LPWStr)]
+        public string HashAlg;    // IntPtr
+
+        public BCryptPkcs1PaddingInfo(TpmAlgId hashAlg)
+        {
+            HashAlg = Native.BCryptHashAlgName(hashAlg);
+        }
+    };
+
+    // BCRYPT_PSS_PADDING_INFO
+    [StructLayout(LayoutKind.Sequential)]
+    public class BCryptPssPaddingInfo
+    {
+        [Interop.MarshalAs(UnmanagedType.LPWStr)]
+        public string HashAlg;    // IntPtr
+        [Interop.MarshalAs(UnmanagedType.U4)]
+        uint SaltSize;
+
+        public BCryptPssPaddingInfo(TpmAlgId hashAlg, uint saltSize = 0)
+        {
+            HashAlg = Native.BCryptHashAlgName(hashAlg);
+            SaltSize = saltSize;
+        }
+    };
+
+    public enum BcryptScheme : uint
+    {
+        Rsassa,
+        Pss,
+        Ecdsa
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct BCryptBuffer : IDisposable
+    {
+        public uint BufferSize;
+        public uint BufferType;
+        //[Interop.MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)]
+        //public byte[] Buffer;
+        IntPtr Buffer;
+
+        public BCryptBuffer(int bufferSize, uint bufferType, byte[] buffer)
+        {
+            BufferSize = (uint)bufferSize;
+            BufferType = bufferType;
+            //Buffer = buffer;
+            Buffer = Marshal.AllocHGlobal(buffer.Length);
+            Marshal.Copy(buffer, 0, Buffer, buffer.Length);
+        }
+
+        public void Dispose()
+        {
+            Globs.Free(ref Buffer);
+        }
+    } // struct BCryptBuffer
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct BCryptBufferDesc : IDisposable
+    {
+        uint Version;
+        uint NumBuffers;
+        IntPtr Buffers;
+
+        public BCryptBufferDesc(uint version, uint numBuffers, BCryptBuffer[] buffers = null)
+        {
+            Version = version;
+            NumBuffers = numBuffers;
+            if (buffers == null)
+            {
+                Buffers = IntPtr.Zero;
+                return;
+            }
+
+            int sizeOfBuffer = Marshal.SizeOf(buffers[0]);
+            Buffers = Marshal.AllocHGlobal(sizeOfBuffer * buffers.Length);
+
+            IntPtr ptr = new IntPtr(Buffers.ToInt64());
+            foreach (var buf in buffers)
+            {
+                Debug.Assert(sizeOfBuffer == Marshal.SizeOf(buf));
+                Marshal.StructureToPtr(buf, ptr, false);
+                ptr = new IntPtr(ptr.ToInt64() + sizeOfBuffer);
+            }
+        }
+
+        public void Dispose()
+        {
+            Globs.Free(ref Buffers);
+        }
+    } // struct BCryptBufferDesc
+
+    public class Csp
+    {
+        public enum AlgId : uint
+        {
+            CAlgRsaKeyX = 0x0000a400,   // CALG_RSA_KEYX
+            CAlgRsaSign = 0x00002400    // CALG_RSA_SIGN
+        }
+
+        // _PUBLICKEYSTRUC
+        public class PublicKeyStruc : TpmStructureBase
+        {
+            [MarshalAs(0)]
+            public byte bType;
+            [MarshalAs(1)]
+            public byte bVersion;
+            [MarshalAs(2)]
+            public ushort reserved;
+            [MarshalAs(3)]
+            public AlgId aiKeyAlg;
+        } // struct PublicKeyStruc
+
+        // _RSAPUBKEY
+        public class RsaPubKey : TpmStructureBase
+        {
+            [MarshalAs(0)]
+            public uint magic;
+            [MarshalAs(1)]
+            public uint bitlen;
+            [MarshalAs(2)]
+            public uint pubexp;
+        } // struct RsaPubKey
+
+
+        public class PrivateKeyBlob : TpmStructureBase
+        {
+            [MarshalAs(0)]
+            public PublicKeyStruc publicKeyStruc;
+
+            [MarshalAs(1)]
+            public RsaPubKey rsaPubKey
+            {
+                get { return _rsaPubKey; }
+
+                set
+                {
+                    _rsaPubKey = value;
+
+                    int keyLen = (int)value.bitlen / 8;
+                    modulus = new byte[keyLen];
+                    prime1 = new byte[keyLen / 2];
+                    prime2 = new byte[keyLen / 2];
+                    exponent1 = new byte[keyLen / 2];
+                    exponent2 = new byte[keyLen / 2];
+                    coefficient = new byte[keyLen / 2];
+                    privateExponent = new byte[keyLen / 2];
+                }
+            }
+            RsaPubKey _rsaPubKey;
+
+            [MarshalAs(2, MarshalType.FixedLengthArray)]
+            public byte[] modulus;
+            [MarshalAs(3, MarshalType.FixedLengthArray)]
+            public byte[] prime1;
+            [MarshalAs(4, MarshalType.FixedLengthArray)]
+            public byte[] prime2;
+            [MarshalAs(5, MarshalType.FixedLengthArray)]
+            public byte[] exponent1;
+            [MarshalAs(6, MarshalType.FixedLengthArray)]
+            public byte[] exponent2;
+            [MarshalAs(7, MarshalType.FixedLengthArray)]
+            public byte[] coefficient;
+            [MarshalAs(8, MarshalType.FixedLengthArray)]
+            public byte[] privateExponent;
+        } // class PrivateKeyBlob
+
+
+        // Trailing parameters are used to populate TpmPublic generated for the key from the blob.
+        public static TpmPrivate CspToTpm(byte[] cspPrivateBlob, out TpmPublic tpmPub,
+                                          TpmAlgId nameAlg = TpmAlgId.Sha1,
+                                          ObjectAttr keyAttrs = ObjectAttr.Decrypt | ObjectAttr.UserWithAuth,
+                                          IAsymSchemeUnion scheme = null,
+                                          SymDefObject symDef = null)
+        {
+            if (scheme == null)
+            {
+                scheme = new NullAsymScheme();
+            }
+            if (symDef == null)
+            {
+                symDef = new SymDefObject();
+            }
+
+            var m = new Marshaller(cspPrivateBlob, DataRepresentation.LittleEndian);
+            var cspPrivate = m.Get<Csp.PrivateKeyBlob>();
+            var keyAlg = cspPrivate.publicKeyStruc.aiKeyAlg;
+            if (keyAlg != Csp.AlgId.CAlgRsaKeyX && keyAlg != Csp.AlgId.CAlgRsaSign)
+            {
+                Globs.Throw<NotSupportedException>("CSP blobs for keys of type " + keyAlg.ToString("X") + " are not supported");
+                tpmPub = new TpmPublic();
+                return new TpmPrivate();
+            }
+
+            var rsaPriv = new Tpm2bPrivateKeyRsa(Globs.ReverseByteOrder(cspPrivate.prime1));
+            var sens = new Sensitive(new byte[0], new byte[0], rsaPriv);
+
+            tpmPub = new TpmPublic(nameAlg, keyAttrs, new byte[0],
+                                   new RsaParms(symDef,
+                                                scheme,
+                                                (ushort)cspPrivate.rsaPubKey.bitlen,
+                                                cspPrivate.rsaPubKey.pubexp),
+                                   new Tpm2bPublicKeyRsa(Globs.ReverseByteOrder(cspPrivate.modulus)));
+
+            return new TpmPrivate(sens.GetTpm2BRepresentation());
+        }
+    } // class BCryptInterface
+}

--- a/TSS.NET/TSS.Net.UWP/CryptoAsym.cs
+++ b/TSS.NET/TSS.Net.UWP/CryptoAsym.cs
@@ -1,0 +1,1010 @@
+﻿/* 
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Numerics;
+using System.Diagnostics;
+using System.Text;
+
+namespace Tpm2Lib
+{
+    /// <summary>
+    /// AsymCryptoSystem is a helper class for doing asymmetric cryptography using TPM data
+    /// structures. It currently does ECC and RSA signing, decryption and ECDH key exchange.
+    /// 
+    /// NOTE: The methods of this class do not attempt to replicate parameters validation
+    ///       performed by the TPM.
+    /// </summary>
+    public sealed class AsymCryptoSystem : IDisposable
+    {
+        private TpmPublic PublicParms;
+        private BCryptKey Key;
+
+        internal static BCryptKey Generate(string algName, uint numBits)
+        {
+            var alg = new BCryptAlgorithm(algName);
+            var key = alg.GenerateKeyPair(numBits);
+            alg.Close();
+            return key;
+        }
+
+        public AsymCryptoSystem()
+        {
+        }
+
+        /// <summary>
+        /// Create a new random software key (public and private) matching the parameters in keyParams.
+        /// </summary>
+        /// <param name="keyParams"></param>
+        /// <returns></returns>
+        public AsymCryptoSystem (TpmPublic keyParams)
+        {
+            TpmAlgId keyAlgId = keyParams.type;
+            PublicParms = keyParams.Copy();
+
+            switch (keyAlgId)
+            {
+                case TpmAlgId.Rsa:
+                {
+                    var rsaParams = keyParams.parameters as RsaParms;
+                    Key = Generate(Native.BCRYPT_RSA_ALGORITHM, rsaParams.keyBits);
+                    if (Key == UIntPtr.Zero)
+                    {
+                        Globs.Throw("Failed to generate RSA key");
+                        return;
+                    }
+                    byte[] blob = Export(Native.BCRYPT_RSAPUBLIC_BLOB);
+                    var m = new Marshaller(blob, DataRepresentation.LittleEndian);
+                    var header = m.Get<BCryptRsaKeyBlob>();
+                    /*var exponent = */m.GetArray<byte>((int)header.cbPublicExp);
+                    var modulus = m.GetArray<byte>((int)header.cbModulus);
+
+                    var pubId = new Tpm2bPublicKeyRsa(modulus);
+                    PublicParms.unique = pubId;
+                    break;
+                }
+                case TpmAlgId.Ecc:
+                {
+                    var eccParms = keyParams.parameters as EccParms;
+                    var alg = RawEccKey.GetEccAlg(keyParams);
+                    if (alg == null)
+                    {
+                        Globs.Throw<ArgumentException>("Unknown ECC curve");
+                        return;
+                    }
+
+                    byte[] keyIs;
+                    Key = Generate(alg, (uint)RawEccKey.GetKeyLength(eccParms.curveID));
+                    //BCRYPT_ECCPRIVATE_BLOB;
+                    keyIs = Key.Export(Native.BCRYPT_ECCPUBLIC_BLOB);
+
+                    // Store the public key
+                    const int offset = 8;
+                    int keySize = 0;
+                    switch (eccParms.curveID)
+                    {
+                        case EccCurve.NistP256:
+                        case EccCurve.BnP256:
+                        case EccCurve.Sm2P256:
+                            keySize = 32;
+                            break;
+                        case EccCurve.NistP384:
+                            keySize = 48;
+                            break;
+                        case EccCurve.NistP521:
+                            keySize = 66;
+                            break;
+                        default:
+                            throw new NotImplementedException();
+                    }
+                    var pubId = new EccPoint(
+                        Globs.CopyData(keyIs, offset, keySize),
+                        Globs.CopyData(keyIs, offset + keySize, keySize));
+                    PublicParms.unique = pubId;
+                    break;
+                }
+                default:
+                    Globs.Throw<ArgumentException>("Algorithm not supported");
+                    break;
+            }
+        }
+
+        public static bool IsCurveSupported(EccCurve curve)
+        {
+            return RawEccKey.IsCurveSupported(curve);
+        }
+
+        /// <summary>
+        /// Create a new AsymCryptoSystem from TPM public parameter. This can then
+        /// be used to validate TPM signatures or encrypt data destined for a TPM.  
+        /// </summary>
+        /// <param name="pubKey"></param>
+        /// <param name="privKey"></param>
+        /// <returns></returns>
+        public static AsymCryptoSystem CreateFrom(TpmPublic pubKey, TpmPrivate privKey = null)
+        {
+            var cs = new AsymCryptoSystem();
+
+            TpmAlgId keyAlgId = pubKey.type;
+            cs.PublicParms = pubKey.Copy();
+
+            // Create an algorithm provider from the provided PubKey
+            switch (keyAlgId)
+            {
+                case TpmAlgId.Rsa:
+                {
+                    RawRsa rr = null;
+                    byte[] prime1 = null,
+                            prime2 = null;
+                    if (privKey != null)
+                    {
+                        rr = new RawRsa(pubKey, privKey);
+                        prime1 = RawRsa.ToBigEndian(rr.P);
+                        prime2 = RawRsa.ToBigEndian(rr.Q);
+                    }
+                    var rsaParams = (RsaParms)pubKey.parameters;
+                    var exponent = rsaParams.exponent != 0
+                                            ? Globs.HostToNet(rsaParams.exponent)
+                                            : RsaParms.DefaultExponent;
+                    var modulus = (pubKey.unique as Tpm2bPublicKeyRsa).buffer;
+                    var alg = new BCryptAlgorithm(Native.BCRYPT_RSA_ALGORITHM);
+                    cs.Key = alg.LoadRSAKey(exponent, modulus, prime1, prime2);
+                    alg.Close();
+                    break;
+                }
+                case TpmAlgId.Ecc:
+                {
+                    var eccParms = (EccParms)pubKey.parameters;
+                    var eccPub = (EccPoint)pubKey.unique;
+                    var algId = RawEccKey.GetEccAlg(pubKey);
+                    if (algId == null)
+                    {
+                        return null;
+                    }
+                    bool isEcdsa = eccParms.scheme.GetUnionSelector() == TpmAlgId.Ecdsa;
+                    byte[] keyBlob = RawEccKey.GetKeyBlob(eccPub.x, eccPub.y, keyAlgId,
+                                                            !isEcdsa, eccParms.curveID);
+                    var alg = new BCryptAlgorithm(algId);
+                    cs.Key = alg.ImportKeyPair(Native.BCRYPT_ECCPUBLIC_BLOB, keyBlob);
+                    alg.Close();
+                    if (cs.Key == UIntPtr.Zero)
+                    {
+                        Globs.Throw("Failed to create new RSA key");
+                        return null;
+                    }
+                    break;
+                }
+                default:
+                    Globs.Throw<ArgumentException>("Algorithm not supported");
+                    cs = null;
+                    break;
+            }
+            return cs;
+        }
+
+        public byte[] Export(string bcryptBlobType)
+        {
+            //RSAParameters parms = RsaProvider.ExportParameters(bcryptBlobType == Native.BCRYPT_RSAPRIVATE_BLOB);
+            //var alg = new BCryptAlgorithm(Native.BCRYPT_RSA_ALGORITHM);
+            //var Key = alg.LoadRSAKey(parms.Exponent, parms.Modulus, parms.P, parms.Q);
+
+            byte[] keyBlob = Key.Export(bcryptBlobType);
+
+            //Key.Destroy();
+            //alg.Close();
+
+            return keyBlob;
+        }
+
+        public byte[] ExportLegacyBlob()
+        {
+            return Export(Native.LEGACY_RSAPRIVATE_BLOB);
+        }
+
+        public byte[] ExportCspBlob()
+        {
+            return ExportLegacyBlob();
+        }
+
+        /// <summary>
+        /// Retrieves key template (containing public key bits).
+        /// </summary>
+        /// <returns></returns>
+        public TpmPublic GetPublicParms()
+        {
+            return PublicParms;
+        }
+
+        public Sensitive GetSensitive()
+        {
+            TpmPublic fromCspPublic;
+            TpmPrivate fromCspPrivate = Csp.CspToTpm(ExportCspBlob(), out fromCspPublic);
+            var m = new Marshaller(fromCspPrivate.buffer);
+            ushort privSize = m.Get<UInt16>();
+            if (fromCspPrivate.buffer.Length != privSize + 2)
+            {
+                Globs.Throw("Invalid key blob");
+            }
+            return m.Get<Sensitive>();
+        }
+
+        /// <summary>
+        /// Sign using the hash algorithm specified during object instantiation. 
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public ISignatureUnion Sign(byte[] data)
+        {
+            return SignData(data, TpmAlgId.Null);
+        }
+
+        /// <summary>
+        /// Sign using a non-default hash algorithm.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="sigHash"></param>
+        /// <returns></returns>
+        public ISignatureUnion SignData(byte[] data, TpmAlgId sigHash)
+        {
+            Debug.Assert(Key != UIntPtr.Zero);
+            var rsaParams = PublicParms.parameters as RsaParms;
+            if (rsaParams != null)
+            {
+                TpmAlgId sigScheme = rsaParams.scheme.GetUnionSelector();
+
+                switch (sigScheme)
+                {
+                    case TpmAlgId.Rsassa:
+                    {
+                        if (sigHash == TpmAlgId.Null)
+                        {
+                            sigHash = (rsaParams.scheme as SigSchemeRsassa).hashAlg;
+                        }
+                        byte[] digest = CryptoLib.HashData(sigHash, data);
+                        byte[] sig = Key.SignHash(digest, BcryptScheme.Rsassa, sigHash);
+                        return new SignatureRsassa(sigHash, sig);
+                    }
+                    case TpmAlgId.Rsapss:
+                    {
+                        Globs.Throw<ArgumentException>("SignData(): PSS scheme is not supported");
+                        return null;
+                    }
+                }
+                Globs.Throw<ArgumentException>("Unsupported signature scheme");
+                return null;
+            }
+
+            var eccParms = PublicParms.parameters as EccParms;
+            if (eccParms != null)
+            {
+                if (eccParms.scheme.GetUnionSelector() != TpmAlgId.Ecdsa)
+                {
+                    Globs.Throw<ArgumentException>("Unsupported ECC sig scheme");
+                    return null;
+                }
+                if (sigHash == TpmAlgId.Null)
+                {
+                    sigHash = (eccParms.scheme as SigSchemeEcdsa).hashAlg;
+                }
+                byte[] digest = CryptoLib.HashData(sigHash, data);
+                //throw new NotImplementedException("ECC signing with BCrypt is not implemented");
+                byte[] sig = Key.SignHash(digest, BcryptScheme.Ecdsa, sigHash);
+                int len = sig.Length / 2;
+                return new SignatureEcdsa(sigHash, Globs.CopyData(sig, 0, len), Globs.CopyData(sig, len, len));
+            }
+
+            // Should never be here
+            Globs.Throw("VerifySignature: Unrecognized asymmetric algorithm");
+            return null;
+        } // SignData()
+
+        /// <summary>
+        /// Verifies the signature over a digest.
+        /// The signing scheme is retrieved from the signature. The verification key
+        /// shall have either compatible or null scheme.
+        /// </summary>
+        /// <param name="digest">Digest to check against the signature</param>
+        /// <param name="signature">The signature</param>
+        /// <returns>True if the verification succeeds.</returns>
+        public bool VerifySignatureOverHash(byte[] digest, ISignatureUnion signature)
+        {
+            return VerifySignature(digest ?? new byte[0], true, signature);
+        }
+
+        /// <summary>
+        /// Verifies the signature over data.
+        /// The data will be hashed internall by the method using hash algorithm from
+        /// the signing scheme digest computed from the specified data buffer.
+        /// The signing scheme is retrieved from the signature. The verification key
+        /// shall have either compatible or null scheme.
+        /// </summary>
+        /// <param name="signedData">Data buffer to check against the signature</param>
+        /// <param name="signature">The signature</param>
+        /// <returns>True if the verification succeeds.</returns>
+        public bool VerifySignatureOverData(byte[] signedData, ISignatureUnion signature)
+        {
+            return VerifySignature(signedData, false, signature);
+        }
+
+        /// <summary>
+        /// Verifies the signature over data or a digest.
+        /// The data will be hashed internall by the method using hash algorithm from
+        /// the signing scheme digest computed from the specified data buffer.
+        /// The signing scheme is retrieved from the signature. The verification key
+        /// shall have either compatible or null scheme.
+        /// </summary>
+        /// <param name="data">Byte buffer containing either digest or data to check against the signature</param>
+        /// <param name="dataIsDigest">Specifies the type of 'data' parameter contents</param>
+        /// <param name="signature">The signature</param>
+        /// <returns>True if the verification succeeds.</returns>
+        private bool VerifySignature(byte[] data, bool dataIsDigest, ISignatureUnion sig)
+        {
+            Debug.Assert(Key != UIntPtr.Zero);
+            TpmAlgId sigScheme = sig.GetUnionSelector();
+            TpmAlgId sigHash = CryptoLib.SchemeHash(sig);
+
+            var rsaParams = PublicParms.parameters as RsaParms;
+            if (rsaParams != null)
+            {
+                var s = sig as SignatureRsa;
+                TpmAlgId keyScheme = rsaParams.scheme.GetUnionSelector();
+
+                if (keyScheme != TpmAlgId.Null && keyScheme != sigScheme)
+                {
+                    Globs.Throw<ArgumentException>("Key scheme and signature scheme do not match");
+                    return false;
+                }
+
+                byte[] digest = dataIsDigest ? data : CryptoLib.HashData(sigHash, data);
+
+                if (sigScheme == TpmAlgId.Rsassa)
+                {
+                    return Key.VerifySignature(digest, s.sig, sigHash, true);
+                }
+                if (sigScheme == TpmAlgId.Rsapss)
+                {
+                    Globs.Throw<ArgumentException>("VerifySignature(): PSS scheme is not supported");
+                    return false;
+                }
+                Globs.Throw<ArgumentException>("VerifySignature(): Unrecognized scheme");
+                return false;
+            }
+
+            var eccParams = PublicParms.parameters as EccParms;
+            if (eccParams != null)
+            {
+                if (eccParams.scheme.GetUnionSelector() != TpmAlgId.Ecdsa)
+                {
+                    Globs.Throw<ArgumentException>("Unsupported ECC sig scheme");
+                    return false;
+                }
+                TpmAlgId keyScheme = eccParams.scheme.GetUnionSelector();
+
+                if (keyScheme != TpmAlgId.Null && keyScheme != sigScheme)
+                {
+                    Globs.Throw<ArgumentException>("Key scheme and signature scheme do not match");
+                    return false;
+                }
+
+                var s = sig as SignatureEcdsa;
+                byte[] digest = dataIsDigest ? data : CryptoLib.HashData(sigHash, data);
+                byte[] sigBlob = Globs.Concatenate(s.signatureR, s.signatureS);
+                return Key.VerifySignature(digest, sigBlob);
+            }
+
+            // Should never be here
+            Globs.Throw("VerifySignature: Unrecognized asymmetric algorithm");
+            return false;
+        } // VerifySignature()
+
+        /// <summary>
+        /// Generates the key exchange key and the public part of the ephemeral key
+        /// using specified encoding parameters in the KDF (ECC only).
+        /// </summary>
+        /// <param name="encodingParms"></param>
+        /// <param name="decryptKeyNameAlg"></param>
+        /// <param name="ephemPub"></param>
+        /// <returns>key exchange key blob</returns>
+        public byte[] EcdhGetKeyExchangeKey(byte[] encodingParms, TpmAlgId decryptKeyNameAlg, out EccPoint ephemPub)
+        {
+            byte[] keyExchangeKey = null;
+            ephemPub = null;
+
+            var eccParms = (EccParms)PublicParms.parameters;
+            int keyBits = RawEccKey.GetKeyLength(eccParms.curveID);
+
+            // Make a new ephemeral key
+            var ephKey = Generate(RawEccKey.GetEccAlg(PublicParms), (uint)keyBits);
+            byte[] ephPub = ephKey.Export(Native.BCRYPT_ECCPUBLIC_BLOB);
+            byte[] otherPub = Key.Export(Native.BCRYPT_ECCPUBLIC_BLOB);
+
+            byte[] herPubX, herPubY;
+            RawEccKey.KeyInfoFromPublicBlob(otherPub, out herPubX, out herPubY);
+
+            byte[] myPubX, myPubY;
+            RawEccKey.KeyInfoFromPublicBlob(ephPub, out myPubX, out myPubY);
+
+            byte[] otherInfo = Globs.Concatenate(new[] { encodingParms, myPubX, herPubX });
+
+            // The TPM uses the following number of bytes from the KDF
+            int bytesNeeded = CryptoLib.DigestSize(decryptKeyNameAlg);
+            keyExchangeKey = new byte[bytesNeeded];
+
+            for (int pos = 0, count = 1, bytesToCopy = 0;
+                 pos < bytesNeeded;
+                 ++count, pos += bytesToCopy)
+            {
+                byte[] secretPrepend = Marshaller.GetTpmRepresentation((UInt32)count);
+                byte[] fragment = ephKey.DeriveKey(Key, decryptKeyNameAlg, secretPrepend, otherInfo);
+                bytesToCopy = Math.Min(bytesNeeded - pos, fragment.Length);
+                Array.Copy(fragment, 0, keyExchangeKey, pos, bytesToCopy);
+            }
+            ephemPub = new EccPoint(myPubX, myPubY);
+            return keyExchangeKey;
+        }
+
+        internal TpmAlgId OaepHash
+        {
+            get
+            {
+                var rsaParams = (RsaParms)PublicParms.parameters;
+                var hashAlg = PublicParms.nameAlg;
+                if (rsaParams.scheme is SchemeOaep)
+                    hashAlg = (rsaParams.scheme as SchemeOaep).hashAlg;
+                else if (rsaParams.scheme is EncSchemeOaep)
+                    hashAlg = (rsaParams.scheme as EncSchemeOaep).hashAlg;
+                return hashAlg;
+            }
+        }
+
+        /// <summary>
+        /// Encrypt dataToEncrypt using the specified encodingParams (RSA only).
+        /// </summary>
+        /// <param name="plainText"></param>
+        /// <param name="label"></param>
+        /// <returns></returns>
+        public byte[] EncryptOaep(byte[] plainText, byte[] label)
+        {
+            if (plainText == null)
+                plainText = new byte[0];
+            if (label == null)
+                label = new byte[0];
+            var paddingInfo = new BCryptOaepPaddingInfo(OaepHash, label);
+            byte[] cipherText = Key.Encrypt(plainText, paddingInfo);
+            return cipherText;
+        }
+
+        public byte[] DecryptOaep(byte[] cipherText, byte[] label)
+        {
+            var paddingInfo = new BCryptOaepPaddingInfo(OaepHash, label);
+            byte[] plainText = Key.Decrypt(cipherText, paddingInfo);
+            return plainText;
+        }
+
+
+        public void Dispose()
+        {
+            Key.Dispose();
+        }
+    } // class AsymCryptoSystem
+
+    public class RawRsa
+    {
+        internal int NumBits = 0;
+
+        /// <summary>
+        /// Modulus (internal key) = P * Q
+        /// </summary>
+        internal BigInteger N;
+
+        /// <summary>
+        /// Public (encryption) exponent (typically 65537)
+        /// </summary>
+        internal BigInteger E;
+
+        /// <summary>
+        ///  The first prime factor (private key)
+        /// </summary>
+        internal BigInteger P;
+
+        /// <summary>
+        ///  The second prime factor
+        /// </summary>
+        internal BigInteger Q;
+
+        /// <summary>
+        /// Private (decryption) exponent
+        /// </summary>
+        internal BigInteger D;
+
+        internal BigInteger InverseQ;
+        internal BigInteger DP;
+        internal BigInteger DQ;
+
+        internal int KeySize { get { return (NumBits + 7) / 8; } }
+
+        /// <summary>
+        /// Returns the public key in TPM-format
+        /// </summary>
+        /// <returns></returns>
+        public byte[] Public { get { return ToBigEndian(N); } }
+
+        /// <summary>
+        /// Returns the RSA private key in TPM format (the first prime number)
+        /// </summary>
+        /// <returns></returns>
+        public byte[] Private { get { return ToBigEndian(P); } }
+
+        /// <summary>
+        ///  Generates new key pair using OS CSP
+        /// </summary>
+        /// <param name="numBits"></param>
+        /// <param name="publicExponent"></param>
+        public RawRsa (int numBits, int publicExponent = 65537)
+        {
+            var key = AsymCryptoSystem.Generate(Native.BCRYPT_RSA_ALGORITHM, (uint)numBits);
+            byte[] blob = key.Export(Native.BCRYPT_RSAFULLPRIVATE_BLOB);
+            var m = new Marshaller(blob, DataRepresentation.LittleEndian);
+            var header = m.Get<BCryptRsaKeyBlob>();
+            E = FromBigEndian(m.GetArray<byte>((int)header.cbPublicExp));
+            N = FromBigEndian(m.GetArray<byte>((int)header.cbModulus));
+            P = FromBigEndian(m.GetArray<byte>((int)header.cbPrime1));
+            Q = FromBigEndian(m.GetArray<byte>((int)header.cbPrime2));
+            DP = FromBigEndian(m.GetArray<byte>((int)header.cbPrime1));
+            DQ = FromBigEndian(m.GetArray<byte>((int)header.cbPrime2));
+            InverseQ = FromBigEndian(m.GetArray<byte>((int)header.cbPrime1));
+            D = FromBigEndian(m.GetArray<byte>((int)header.cbModulus));
+        }
+
+        /// <summary>
+        /// Instantiates the object using a TPM generated key pair
+        /// </summary>
+        /// <param name="pub"></param>
+        /// <param name="priv"></param>
+        public RawRsa(TpmPublic pub, TpmPrivate priv)
+        {
+            var m = new Marshaller(priv.buffer);
+            var privSize = m.Get<UInt16>();
+            // Assert that the private key blob is in plain text 
+            Debug.Assert(priv.buffer.Length == privSize + 2);
+            var sens = m.Get<Sensitive>();
+            Init(pub, sens.sensitive as Tpm2bPrivateKeyRsa);
+        }
+
+        void Init(TpmPublic pub, Tpm2bPrivateKeyRsa priv)
+        {
+            var parms = pub.parameters as RsaParms;
+
+            NumBits = parms.keyBits;
+
+            E = new BigInteger(parms.exponent == 0 ? RsaParms.DefaultExponent
+                                                   : BitConverter.GetBytes(parms.exponent));
+            N = FromBigEndian((pub.unique as Tpm2bPublicKeyRsa).buffer);
+            P = FromBigEndian(priv.buffer);
+            Q = N / P;
+            Debug.Assert(N % P == BigInteger.Zero);
+
+            BigInteger PHI = N - (P + Q - BigInteger.One);
+            D = ModInverse(E, PHI);
+            InverseQ = ModInverse(Q, P);
+            DP = D % (P - BigInteger.One);
+            DQ = D % (Q - BigInteger.One);
+        }
+
+        public static byte[] GetLabel(string label)
+        {
+            return GetLabel(Encoding.ASCII.GetBytes(label));
+        }
+
+        public static byte[] GetLabel(byte[] data)
+        {
+            if (data == null)
+            {
+                return new byte[0];
+            }
+            if (data.Length == 0)
+            {
+                return data;
+            }
+            int labelSize = 0;
+            while (labelSize < data.Length && data[labelSize++] != 0)
+            {
+                continue;
+            }
+            var label = new byte[labelSize + (data[labelSize - 1] != 0 ? 1 : 0)];
+            Array.Copy(data, label, labelSize);
+            return label;
+        }
+
+        internal static BigInteger ModInverse(BigInteger a, BigInteger b)
+        {
+            BigInteger dividend = a % b;
+            BigInteger divisor = b;
+
+            BigInteger lastX = BigInteger.One;
+            BigInteger currX = BigInteger.Zero;
+
+            while (divisor.Sign > 0)
+            {
+                BigInteger quotient = dividend / divisor;
+                BigInteger remainder = dividend % divisor;
+
+                if (remainder.Sign <= 0)
+                {
+                    break;
+                }
+
+                BigInteger nextX = lastX - currX * quotient;
+
+                lastX = currX;
+                currX = nextX;
+
+                dividend = divisor;
+                divisor = remainder;
+            }
+
+            if (divisor != BigInteger.One)
+            {
+                throw new Exception("ModInverse(): Not coprime");
+            }
+
+            return (currX.Sign < 0 ? currX + b : currX);
+        }
+
+        /// <summary>
+        /// Translate a byte array representing a big-endian (MSB first, possibly > 0x7F)
+        /// TPM-style number to a BigInteger.
+        /// </summary>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        public static BigInteger FromBigEndian(byte[] b)
+        {
+            return new BigInteger(ToLittleEndian(b));
+        }
+
+        /// <summary>
+        /// Translates a BigInt into a TPM-style big-endian byte array.
+        /// By default removes MSB-zeros.
+        /// If sizeWanted is specified, pads with MSB-zeros to desired length.
+        /// </summary>
+        /// <param name="b"></param>
+        /// <param name="sizeWanted"></param>
+        /// <returns></returns>
+        public static byte[] ToBigEndian(BigInteger b, int sizeWanted = -1)
+        {
+            return ToBigEndian(b.ToByteArray());
+        }
+
+        /// <summary>
+        /// Translate a byte array representing a big-endian (MSB first, possibly > 0x7F)
+        /// TPM-style number to the little endian representation.
+        /// </summary>
+        /// <param name="b"></param>
+        /// <returns></returns>
+        internal static byte[] ToLittleEndian(byte[] b)
+        {
+            int len = b.Length;
+            var b2 = new byte[len + (b[0] > 0x7F ? 1 : 0)];
+
+            for (int j = 0; j < len; j++)
+            {
+                b2[j] = b[len - 1 - j];
+            }
+            return b2;
+        }
+
+        /// <summary>
+        /// Translates a little endian number represented as a byte array to TPM-style
+        /// big-endian byte array. By default removes MSB-zeros.
+        /// If sizeWanted is specified, pads with MSB-zeros to desired length.
+        /// </summary>
+        /// <param name="b"></param>
+        /// <param name="sizeWanted"></param>
+        /// <returns></returns>
+        internal static byte[] ToBigEndian(byte[] b, int sizeWanted = -1)
+        {
+            int len = b.Length;
+
+            // Count trailing zeros (MSB zeros to be removed)
+            while (len > 0 && b[len - 1] == 0)
+            {
+                --len;
+            }
+            if (sizeWanted == -1)
+            {
+                sizeWanted = len;
+            }
+
+            int pad = sizeWanted - len;
+            if (pad < 0)
+            {
+                Globs.Throw<ArgumentException>("ToBigEndian(): Too short size requested");
+                return new byte[0];
+            }
+
+            var b2 = new byte[sizeWanted];
+
+            for (int j = 0; j < len; j++)
+            {
+                b2[j + pad] = b[len - 1 - j];
+            }
+            return b2;
+        }
+
+        public byte[] RawEncrypt(byte[] plain)
+        {
+            BigInteger plainX = FromBigEndian(plain);
+            BigInteger cipher = BigInteger.ModPow(plainX, E, N);
+            byte[] cipherX = ToBigEndian(cipher, KeySize);
+            return cipherX;
+        }
+
+        public byte[] RawDecrypt(byte[] cipher)
+        {
+            BigInteger cipherX = FromBigEndian(cipher);
+            BigInteger plain = BigInteger.ModPow(cipherX, D, N);
+            byte[] plainX = ToBigEndian(plain, KeySize);
+            return plainX;
+        }
+
+        public byte[] OaepEncrypt(byte[] data, TpmAlgId hashAlg, byte[] encodingParms)
+        {
+            int encLen = NumBits / 8;
+            byte[] zeroTermEncoding = GetLabel(encodingParms);
+            byte[] encoded = CryptoEncoders.OaepEncode(data, zeroTermEncoding, hashAlg, encLen);
+            BigInteger message = FromBigEndian(encoded);
+            BigInteger cipher = BigInteger.ModPow(message, E, N);
+            byte[] encMessageBigEnd = ToBigEndian(cipher, KeySize);
+            if (encMessageBigEnd.Length < encLen)
+                encMessageBigEnd = Globs.AddZeroToBeginning(encMessageBigEnd, encLen - encMessageBigEnd.Length);
+            return encMessageBigEnd;
+        }
+
+        public byte[] OaepDecrypt(byte[] cipherText, TpmAlgId hashAlg, byte[] encodingParms)
+        {
+            byte[] zeroTermEncoding = GetLabel(encodingParms);
+            BigInteger cipher = FromBigEndian(cipherText);
+            BigInteger plain = BigInteger.ModPow(cipher, D, N);
+            byte[] encMessage = ToBigEndian(plain, KeySize - 1);
+            byte[] message;
+
+            // Hack - be robust to leading zeros
+            while (true)
+            {
+                bool decodeOk = CryptoEncoders.OaepDecode(encMessage, zeroTermEncoding, hashAlg, out message);
+                if (decodeOk)
+                {
+                    break;
+                }
+                encMessage = Globs.AddZeroToBeginning(encMessage);
+            }
+            return message;
+        }
+
+        public byte[] PssSign(byte[] m, TpmAlgId hashAlg)
+        {
+            // The TPM uses the maximum salt length
+            int defaultPssSaltLength = 0; // KeySize - CryptoLib.DigestSize(hashAlg) - 1 - 1;
+
+            // Encode
+            byte[] em = CryptoEncoders.PssEncode(m, hashAlg, defaultPssSaltLength, NumBits - 1);
+            BigInteger message = FromBigEndian(em);
+
+            // Sign
+            BigInteger sig = BigInteger.ModPow(message, D, N);
+            byte[] signature = ToBigEndian(sig, KeySize);
+            return signature;
+        }
+
+        public bool PssVerify(byte[] m, byte[] signature, TpmAlgId hashAlg)
+        {
+            // The TPM uses the maximum salt length
+            int defaultPssSaltLength = 0; //  KeySize - CryptoLib.DigestSize(hashAlg) - 1 - 1;
+            BigInteger sig = FromBigEndian(signature);
+            BigInteger emx = BigInteger.ModPow(sig, E, N);
+
+            byte[] em = ToBigEndian(emx, KeySize);
+
+            bool ok = CryptoEncoders.PssVerify(m, em, defaultPssSaltLength, NumBits - 1, hashAlg);
+            return ok;
+        }
+
+        public byte[] PkcsSign(byte[] m, TpmAlgId hashAlg)
+        {
+            int k = KeySize;
+            byte[] em = CryptoEncoders.Pkcs15Encode(m, k, hashAlg);
+            BigInteger message = FromBigEndian(em);
+            BigInteger sig = BigInteger.ModPow(message, D, N);
+            byte[] signature = ToBigEndian(sig, KeySize);
+            return signature;
+        }
+
+        public bool PkcsVerify(byte[] m, byte[] s, TpmAlgId hashAlg)
+        {
+            if (s.Length != KeySize)
+            {
+                Globs.Throw<ArgumentException>("PkcsVerify: Invalid signature");
+                return false;
+            }
+            int k = KeySize;
+            BigInteger sig = FromBigEndian(s);
+            BigInteger emx = BigInteger.ModPow(sig, E, N);
+
+            byte[] emDecrypted = ToBigEndian(emx, KeySize);
+
+            byte[] emPrime = CryptoEncoders.Pkcs15Encode(m, k, hashAlg);
+            if (!Globs.ArraysAreEqual(emPrime, emDecrypted))
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    internal class RawEccKey
+    {
+        internal struct EccInfo
+        {
+            internal uint Magic;
+            internal bool Public;   // Not private
+            internal int KeyLength; // Bits
+            internal bool Ecdh;     // Not ECDSA
+        }
+
+        internal static EccInfo[] AlgInfo = {
+
+            //#define BCRYPT_ECDH_PUBLIC_P256_MAGIC   0x314B4345  // ECK1
+            new EccInfo {Magic = 0x314B4345, KeyLength = 256, Ecdh = true, Public = true},
+            //#define BCRYPT_ECDH_PRIVATE_P256_MAGIC  0x324B4345  // ECK2
+            new EccInfo {Magic = 0x324B4345, KeyLength = 256, Ecdh = true, Public = false},
+            //#define BCRYPT_ECDH_PUBLIC_P384_MAGIC   0x334B4345  // ECK3
+            new EccInfo {Magic = 0x334B4345, KeyLength = 384, Ecdh = true, Public = true},
+            //#define BCRYPT_ECDH_PRIVATE_P384_MAGIC  0x344B4345  // ECK4
+            new EccInfo {Magic = 0x344B4345, KeyLength = 384, Ecdh = true, Public = false},
+            //#define BCRYPT_ECDH_PUBLIC_P521_MAGIC   0x354B4345  // ECK5
+            new EccInfo {Magic = 0x354B4345, KeyLength = 521, Ecdh = true, Public = true},
+            //#define BCRYPT_ECDH_PRIVATE_P521_MAGIC  0x364B4345  // ECK6
+            new EccInfo {Magic = 0x364B4345, KeyLength = 521, Ecdh = true, Public = false},
+
+            //#define BCRYPT_ECDSA_PUBLIC_P256_MAGIC  0x31534345  // ECS1
+            new EccInfo {Magic = 0x31534345, KeyLength = 256, Ecdh = false, Public = true},
+            //#define BCRYPT_ECDSA_PRIVATE_P256_MAGIC 0x32534345  // ECS2
+            new EccInfo {Magic = 0x32534345, KeyLength = 256, Ecdh = false, Public = false},
+            //#define BCRYPT_ECDSA_PUBLIC_P384_MAGIC  0x33534345  // ECS3
+            new EccInfo {Magic = 0x33534345, KeyLength = 384, Ecdh = false, Public = true},
+            //#define BCRYPT_ECDSA_PRIVATE_P384_MAGIC 0x34534345  // ECS4
+            new EccInfo {Magic = 0x34534345, KeyLength = 384, Ecdh = false, Public = false},
+            //#define BCRYPT_ECDSA_PUBLIC_P521_MAGIC  0x35534345  // ECS5
+            new EccInfo {Magic = 0x35534345, KeyLength = 521, Ecdh = false, Public = true},
+            //#define BCRYPT_ECDSA_PRIVATE_P521_MAGIC 0x36534345  // ECS6
+            new EccInfo {Magic = 0x36534345, KeyLength = 521, Ecdh = false, Public = false}
+        };
+
+        internal static int GetKeyLength(EccCurve curve)
+        {
+            switch (curve)
+            {
+                case EccCurve.NistP256:
+                    return 256;
+                case EccCurve.NistP384:
+                    return 384;
+                case EccCurve.NistP521:
+                    return 521;
+            }
+            Globs.Throw<ArgumentException>("GetKeyLength(): Invalid ECC curve");
+            return -1;
+        }
+
+        internal static uint MagicFromTpmAlgId(TpmAlgId algId, bool isEcdh, EccCurve curve, bool publicKey)
+        {
+            uint res = AlgInfo.FirstOrDefault(x => (x.Public == publicKey && 
+                                                    x.KeyLength == GetKeyLength(curve) &&
+                                                    x.Ecdh == isEcdh)).Magic;
+            if (res == 0)
+            {
+                Globs.Throw("Unrecognized ECC parameter set");
+            }
+            return res;
+        }
+
+        internal static byte[] GetKeyBlob(byte[] x, byte[] y, TpmAlgId alg, bool isEcdh, EccCurve curve)
+        {
+            var m = new Marshaller();
+            byte[] magic = BitConverter.GetBytes(MagicFromTpmAlgId(alg, isEcdh, curve, true));
+            m.Put(magic, "");
+            int keyBits = GetKeyLength(curve);
+            int keySizeBytes = (keyBits + 7) / 8;
+
+            if (x.Length != keySizeBytes || y.Length != keySizeBytes)
+            {
+                Globs.Throw<ArgumentException>("GetKeyBlob: Malformed ECC key");
+                return new byte[0];
+            }
+
+            var size = Globs.ReverseByteOrder(Globs.HostToNet(keySizeBytes));
+            m.Put(size, "len");
+            m.Put(x, "x");
+            m.Put(y, "y");
+            var res = m.GetBytes();
+            return res;
+        }
+
+        internal static void KeyInfoFromPublicBlob(byte[] blob, out byte[] x, out byte[] y)
+        {
+            x = null;
+            y = null;
+            var m = new Marshaller(blob);
+            uint magic = BitConverter.ToUInt32(m.GetNBytes(4), 0);
+            bool magicOk = AlgInfo.Any(xx => xx.Magic == magic);
+
+            if (!magicOk)
+            {
+                Globs.Throw<ArgumentException>("KeyInfoFromPublicBlob: Public key blob magic not recognized");
+            }
+
+            uint cbKey = BitConverter.ToUInt32(m.GetNBytes(4), 0);
+
+            x = m.GetNBytes((int)cbKey);
+            y = m.GetNBytes((int)cbKey);
+        }
+
+        internal static bool IsCurveSupported(EccCurve curve)
+        {
+            int curveIndex = (int)curve;
+
+            if (curveIndex < EcdsaCurveIDs.Length &&
+                EcdsaCurveIDs[curveIndex] != null)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        static string[] EcdsaCurveIDs = { null, null, null,
+                            Native.BCRYPT_ECDSA_P256_ALGORITHM,
+                            Native.BCRYPT_ECDSA_P384_ALGORITHM,
+                            Native.BCRYPT_ECDSA_P521_ALGORITHM
+                        };
+        static string[] EcdhCurveIDs = { null, null, null,
+                            Native.BCRYPT_ECDH_P256_ALGORITHM,
+                            Native.BCRYPT_ECDH_P384_ALGORITHM,
+                            Native.BCRYPT_ECDH_P521_ALGORITHM
+                        };
+
+        internal static string
+        GetEccAlg(TpmPublic pub)
+        {
+            if (pub.unique.GetUnionSelector() != TpmAlgId.Ecc)
+            {
+                return null;
+            }
+
+            var eccParms = (EccParms)pub.parameters;
+
+            bool signing = pub.objectAttributes.HasFlag(ObjectAttr.Sign);
+            bool encrypting = pub.objectAttributes.HasFlag(ObjectAttr.Decrypt);
+            if (!(signing ^ encrypting))
+            {
+                Globs.Throw<ArgumentException>("ECC Key must either sign or decrypt");
+                return null;
+            }
+            var scheme = eccParms.scheme.GetUnionSelector();
+            if (signing && scheme != TpmAlgId.Ecdsa && scheme != TpmAlgId.Null)
+            {
+                Globs.Throw<ArgumentException>("Unsupported ECC signing scheme");
+                return null;
+            }
+
+            if (!IsCurveSupported(eccParms.curveID))
+            {
+                Globs.Throw<ArgumentException>("Unsupported ECC curve");
+                return null;
+            }
+            int curveIndex = (int)eccParms.curveID;
+            return signing ? EcdsaCurveIDs[curveIndex] : EcdhCurveIDs[curveIndex];
+        }
+    } // class CngEccKey
+}

--- a/TSS.NET/TSS.Net.UWP/CryptoLib.cs
+++ b/TSS.NET/TSS.Net.UWP/CryptoLib.cs
@@ -1,0 +1,640 @@
+﻿/* 
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace Tpm2Lib
+{
+    public static class CryptoLib
+    {
+        public static byte[] HashData(TpmAlgId algId, byte[] dataToHash)
+        {
+            if (dataToHash == null)
+                dataToHash = new byte[0];
+
+            string algName = Native.BCryptHashAlgName(algId);
+            if (string.IsNullOrEmpty(algName))
+            {
+                Globs.Throw<ArgumentException>("HashData(): Unsupported hash algorithm " + algId);
+                return null;
+            }
+
+            var alg = new BCryptAlgorithm(algName);
+            var digest = alg.HashData(dataToHash);
+            alg.Close();
+            return digest;
+        }
+
+        static readonly TpmAlgId[] DefinedHashAlgorithms = {
+            TpmAlgId.Sha1, TpmAlgId.Sha256, TpmAlgId.Sha384, TpmAlgId.Sha512
+        };
+
+        public static byte[] HashData(TpmAlgId alg, byte[][] dataToHash)
+        {
+            return HashData(alg, Globs.Concatenate(dataToHash));
+        }
+
+        public static bool IsHashAlgorithm(TpmAlgId alg)
+        {
+            return DefinedHashAlgorithms.Any(id => alg == id);
+        }
+
+        public static byte[] HashData(TpmAlgId alg, byte[] data1, byte[] data2)
+        {
+            return HashData(alg, Globs.Concatenate(data1, data2));
+        }
+
+        public static byte[] HashData(TpmAlgId alg, byte[] data1, byte[] data2, byte[] data3)
+        {
+            return HashData(alg, new[] {data1, data2, data3});
+        }
+
+        public static bool IsSupported(TpmAlgId algId)
+        {
+            switch (algId)
+            {
+                case TpmAlgId.Sha1:
+                case TpmAlgId.Sha256:
+                case TpmAlgId.Sha384:
+                case TpmAlgId.Sha512:
+                case TpmAlgId.Cmac:
+                    return true;
+            }
+            return false;
+        }
+
+        public static int DigestSize(TpmAlgId hashAlgId)
+        {
+            switch (hashAlgId)
+            {
+                case TpmAlgId.Sha1:
+                    return 20;
+                case TpmAlgId.Sha256:
+                    return 32;
+                case TpmAlgId.Sha384:
+                    return 48;
+                case TpmAlgId.Sha512:
+                    return 64;
+                case TpmAlgId.Sm3256:
+                    return 32;
+                case TpmAlgId.Null:
+                    return 0;
+            }
+            Globs.Throw<ArgumentException>("DigestSize(): Unsupported hash algorithm");
+            return 0;
+        }
+
+        public static int BlockSize(TpmAlgId algId)
+        {
+            switch (algId)
+            {
+                case TpmAlgId.Sha1:
+                    return 64;
+                case TpmAlgId.Sha256:
+                    return 64;
+                case TpmAlgId.Sha384:
+                    return 128;
+                case TpmAlgId.Sha512:
+                    return 128;
+                case TpmAlgId.Sm3256:
+                    return 64;
+                case TpmAlgId.Cmac:
+                    return 16;
+                case TpmAlgId.Null:
+                    return 0;
+            }
+            Globs.Throw<ArgumentException>("BlockSize{}: Unsupported hash or MAC  algorithm");
+            return 0;
+        }
+
+        public static TpmAlgId SchemeHash (ISignatureUnion sig)
+        {
+            if (sig is SignatureRsa)
+                return (sig as SignatureRsa).hash;
+            if (sig is SignatureEcc)
+                return (sig as SignatureEcc).hash;
+            if (sig is TpmHash)
+                return (sig as TpmHash).HashAlg;
+            return TpmAlgId.Null;
+        }
+
+        public static byte[] Hmac(TpmAlgId hashAlgId, byte[] key, byte[] data)
+        {
+            string algName = Native.BCryptHashAlgName(hashAlgId);
+            if (string.IsNullOrEmpty(algName))
+            {
+                Globs.Throw<ArgumentException>("CryptoLib.Hmac(): Unsupported hash algorithm " + hashAlgId);
+                return null;
+            }
+
+            var alg = new BCryptAlgorithm(algName, Native.BCRYPT_ALG_HANDLE_HMAC);
+            var digest = alg.HmacData(key, data);
+            alg.Close();
+            return digest;
+        }
+
+        public static byte[] Mac(TpmAlgId symAlg, TpmAlgId macScheme, byte[] key, byte[] data)
+        {
+            if (symAlg != TpmAlgId.Aes)
+            {
+                Globs.Throw<ArgumentException>("CryptoLib.Mac(): Unsupported symmetric algorithm" + symAlg);
+                return null;
+            }
+            if (macScheme != TpmAlgId.Cmac)
+            {
+                Globs.Throw<ArgumentException>("CryptoLib.Mac(): Unsupported MAC scheme " + macScheme);
+                return null;
+            }
+
+            var alg = new BCryptAlgorithm(Native.BCRYPT_AES_CMAC_ALGORITHM);
+            var digest = alg.HmacData(key, data);
+            alg.Close();
+            return digest;
+        }
+
+        public static bool VerifyHmac(TpmAlgId hashAlg, byte[] key, byte[] data, byte[] sig)
+        {
+            return Globs.ArraysAreEqual(sig, Hmac(hashAlg, key, data));
+        }
+
+        public static byte[] I2Osp4(int x)
+        {
+            var osp = new byte[4];
+            osp[0] = (byte)((x & 0xFF000000) >> 24);
+            osp[1] = (byte)((x & 0x00FF0000) >> 16);
+            osp[2] = (byte)((x & 0x0000FF00) >> 8);
+            osp[3] = (byte)(x & 0x000000FF);
+            return osp;
+        }
+
+        public static byte[] MGF(byte[] z, int length, TpmAlgId hashAlg)
+        {
+            var T = new byte[length];
+            int pos = 0;
+            for (int j = 0; pos < length; j++)
+            {
+                byte[] c = I2Osp4(j);
+                byte[] tmp = HashData(hashAlg, new[]{z, c});
+
+                foreach (byte t in tmp)
+                {
+                    T[pos++] = t;
+                    if (pos >= length)
+                    {
+                        break;
+                    }
+                }
+            }
+            return T;
+        }
+
+        public static byte[] KdfThenXor(TpmAlgId hashAlg, byte[] key,
+                                        byte[] contextU, byte[] contextV, byte[] data)
+        {
+            var mask = KDF.KDFa(hashAlg, key, "XOR", contextU, contextV, data.Length * 8);
+            return XorEngine.Xor(data, mask);
+        }
+    }
+
+    public class CryptoEncoders
+    {
+        /// <summary>
+        /// EME-OAEP PKCS1.2, section 9.1.1.1.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="encodingParameters"></param>
+        /// <param name="hashAlg"></param>
+        /// <param name="modulusNumBytes"></param>
+        /// <returns></returns>
+        public static byte[] OaepEncode(byte[] message, byte[] encodingParameters,
+                                        TpmAlgId hashAlg, int modulusNumBytes) 
+        {
+            int encodedMessageLength = modulusNumBytes - 1;
+            int messageLength = message.Length;
+            int hashLength = CryptoLib.DigestSize(hashAlg);
+
+            // 1 (Step numbers from RSA labs spec.)
+            // Ignore the ParametersLength limitation
+
+            // 2
+            if (messageLength > encodedMessageLength - 2 * hashLength - 1)
+            {
+                Globs.Throw<ArgumentException>("OaepEncode: Input message too long");
+                return new byte[0];
+            }
+            int psLen = encodedMessageLength - messageLength - 2 * hashLength - 1;
+            var ps = new byte[psLen];
+
+            // 3 (Not needed.)
+            for (int j = 0; j < psLen; j++)
+                ps[j] = 0;
+
+            // 4
+            byte[] pHash = CryptoLib.HashData(hashAlg, encodingParameters);
+
+            // 5
+            var db = new byte[hashLength + psLen + 1 + messageLength];
+            var one = new byte[1];
+
+            one[0] = 1;
+            pHash.CopyTo(db, 0);
+            ps.CopyTo(db, pHash.Length);
+            one.CopyTo(db, pHash.Length + ps.Length);
+            message.CopyTo(db, pHash.Length + ps.Length + 1);
+
+            // 6
+            byte[] seed = Globs.GetRandomBytes(hashLength);
+
+            // 7
+            byte[] dbMask = CryptoLib.MGF(seed, encodedMessageLength - hashLength, hashAlg);
+
+            // 8
+            byte[] maskedDb = XorEngine.Xor(db, dbMask);
+
+            // 9
+            byte[] seedMask = CryptoLib.MGF(maskedDb, hashLength, hashAlg);
+
+            // 10
+            byte[] maskedSeed = XorEngine.Xor(seed, seedMask);
+
+            //11
+            var encodedMessage = new byte[maskedSeed.Length + maskedDb.Length];
+            maskedSeed.CopyTo(encodedMessage, 0);
+            maskedDb.CopyTo(encodedMessage, maskedSeed.Length);
+
+            // 12
+            return encodedMessage;
+        }
+
+        public static bool OaepDecode(byte[] eMx, byte[] encodingParms,
+                                      TpmAlgId hashAlg, out byte[] decoded)
+        {
+            decoded = new byte[0];
+
+            var em = new byte[eMx.Length + 1];
+            Array.Copy(eMx, 0, em, 1, eMx.Length);
+
+            int hLen = CryptoLib.DigestSize(hashAlg);
+            int k = em.Length;
+
+            // a.
+            byte[] lHash = CryptoLib.HashData(hashAlg, encodingParms);
+
+            // b.
+            byte y = em[0];
+            byte[] maskedSeed = Globs.CopyData(em, 1, hLen);
+            byte[] maskedDB = Globs.CopyData(em, 1 + hLen);
+
+            // c.
+            byte[] seedMask = CryptoLib.MGF(maskedDB, hLen, hashAlg);
+
+            // d.
+            byte[] seed = XorEngine.Xor(maskedSeed, seedMask);
+
+            // e.
+            byte[] dbMask = CryptoLib.MGF(seed, k - hLen - 1, hashAlg);
+
+            // f.
+            byte[] db = XorEngine.Xor(maskedDB, dbMask);
+
+            // g.
+            byte[] lHashPrime = Globs.CopyData(db, 0, hLen);
+
+            // Look for the zero..
+            int j;
+
+            for (j = hLen; j < db.Length; j++)
+            {
+                if (db[j] == 0)
+                {
+                    continue;
+                }
+
+                if (db[j] == 1)
+                {
+                    break;
+                }
+
+                return false;
+            }
+
+            if (j == db.Length - 1)
+            {
+                return false;
+            }
+
+            byte[] m = Globs.CopyData(db, j + 1);
+
+            if (y != 0)
+            {
+                return false;
+            }
+
+            if (!Globs.ArraysAreEqual(lHash, lHashPrime))
+            {
+                return false;
+            }
+
+            decoded = m;
+            return true;
+        }
+
+        public static byte[] PssEncode(byte[] m, TpmAlgId hashAlg, int sLen, int emBits)
+        {
+            var emLen = (int)Math.Ceiling(1.0 * emBits / 8);
+            int hLen = CryptoLib.DigestSize(hashAlg);
+
+            // 1 - Ignore
+            // 2
+            byte[] mHash = TpmHash.FromData(hashAlg, m);
+
+            // 3
+            if (emLen < hLen + sLen + 2)
+            {
+                Globs.Throw("PssEncode: Encoding error");
+                return new byte[0];
+            }
+
+            // 4
+            byte[] salt = Globs.GetRandomBytes(sLen);
+
+            // 5
+            byte[] mPrime = Globs.Concatenate(new[] { Globs.ByteArray(8, 0),
+                                                      mHash,
+                                                      salt});
+
+            // 6
+            byte[] h = CryptoLib.HashData(hashAlg, mPrime);
+
+            // 7
+            byte[] ps = Globs.GetZeroBytes(emLen - sLen - hLen - 2);
+
+            // 8 
+            byte[] db = Globs.Concatenate(new[] { ps,
+                                                  new byte[] {0x01},
+                                                  salt});
+
+            // 9 
+            byte[] dbMask = CryptoLib.MGF(h, emLen - hLen - 1, hashAlg);
+
+            // 10
+            byte[] maskedDb = XorEngine.Xor(db, dbMask);
+
+            // 11
+            int numZeroBits = 8 * emLen - emBits;
+            byte mask = GetByteMask(numZeroBits);
+            maskedDb[0] &= mask;
+
+            // 12
+            byte[] em = Globs.Concatenate(new[] { maskedDb,
+                                                  h,
+                                                  new byte[] {0xbc}});
+            // 13 
+            return em;
+        }
+
+        /// <summary>
+        /// PSS verify.  Note: we expect the caller to do the hash.
+        /// </summary>
+        /// <param name="m"></param>
+        /// <param name="em"></param>
+        /// <param name="sLen"></param>
+        /// <param name="emBits"></param>
+        /// <param name="hashAlg"></param>
+        /// <returns></returns>
+        public static bool PssVerify(byte[] m, byte[] em, int sLen, int emBits, TpmAlgId hashAlg)
+        {
+            var emLen = (int)Math.Ceiling(1.0 * emBits / 8);
+            int hLen = CryptoLib.DigestSize(hashAlg);
+            // 1 - Skip
+            // 2
+            byte[] mHash = TpmHash.FromData(hashAlg, m);
+
+            // 3
+            if (emLen < hLen + sLen + 2)
+            {
+                return false;
+            }
+
+            // 4
+            if (em[em.Length - 1] != 0xbc)
+            {
+                return false;
+            }
+
+            // 5
+            byte[] maskedDB = Globs.CopyData(em, 0, emLen - hLen - 1);
+            byte[] h = Globs.CopyData(em, emLen - hLen - 1, hLen);
+
+            // 6
+            int numZeroBits = 8 * emLen - emBits;
+            // First numZero bits is zero in mask
+            byte mask = GetByteMask(numZeroBits);
+            if ((maskedDB[0] & mask) != maskedDB[0])
+            {
+                return false;
+            }
+
+            // 7
+            byte[] dbMask = CryptoLib.MGF(h, emLen - hLen - 1, hashAlg);
+
+            // 8
+            byte[] db = XorEngine.Xor(maskedDB, dbMask);
+
+            // 9
+            int numZeroBits2 = 8 * emLen - emBits;
+            byte mask2 = GetByteMask(numZeroBits2);
+            db[0] &= mask2;
+
+            // 10
+            for (int j = 0; j < emLen - hLen - sLen - 2; j++)
+            {
+                if (db[j] != 0)
+                {
+                    return false;
+                }
+
+            }
+            if (db[emLen - hLen - sLen - 1 - 1] != 1)
+            {
+                return false;
+            }
+
+            // 11
+            byte[] salt = Globs.CopyData(db, db.Length - sLen);
+
+            // 12
+            byte[] mPrime = Globs.Concatenate(new[] { Globs.ByteArray(8, 0), mHash, salt});
+
+            // 13
+            byte[] hPrime = TpmHash.FromData(hashAlg, mPrime);
+
+            // 14
+            bool match = Globs.ArraysAreEqual(h, hPrime);
+            if (match == false)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Gets a byte with the first (MSB) numBits =0;
+        /// </summary>
+        /// <param name="numBits"></param>
+        /// <returns></returns>
+        private static byte GetByteMask(int numBits)
+        {
+            Debug.Assert(numBits >= 0 && numBits <= 8);
+            byte mask = 0xFF;
+            for (int j = 1; j <= numBits; j++)
+            {
+                mask &= (byte)(0xff >> j);
+            }
+            return mask;
+        }
+
+        public static byte[] Pkcs15Encode(byte[] m, int emLen, TpmAlgId hashAlg)
+        {
+            byte[] prefix;
+            switch (hashAlg)
+            {
+                case TpmAlgId.Sha1:
+                    prefix = new byte[]
+                    {0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b,
+                     0x0e, 0x03, 0x02, 0x1a, 0x05, 0x00, 0x04, 0x14};
+                    break;
+                case TpmAlgId.Sha256:
+                    prefix = new byte[] {
+                        0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01,
+                        0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20
+                    };
+                    break;
+                case TpmAlgId.Sha384:
+                    prefix = new byte[] {
+                        0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01,
+                        0x65, 0x03, 0x04, 0x02, 0x02, 0x05, 0x00, 0x04, 0x30
+                    };
+                    break;
+                case TpmAlgId.Sha512:
+                    prefix = new byte[] {
+                        0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01,
+                        0x65, 0x03, 0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40
+                    };
+                    break;
+                default:
+                    Globs.Throw<ArgumentException>("Pkcs15Encode: Unsupported hashAlg");
+                    return new byte[0];
+            }
+            byte[] messageHash = TpmHash.FromData(hashAlg, m);
+            byte[] T = Globs.Concatenate(prefix, messageHash);
+            int tLen = T.Length;
+
+            if (emLen < tLen + 11)
+            {
+                Globs.Throw<ArgumentException>("Pkcs15Encode: Encoded message is too short");
+                return new byte[0];
+            }
+
+            byte[] ps = Globs.ByteArray(emLen - tLen - 3, 0xff);
+            byte[] em = Globs.Concatenate(new[] { new byte[] {0x00, 0x01}, ps,
+                                                  new byte[] {0x00}, T});
+            return em;
+        }
+    }
+
+    public class XorEngine
+    {
+        public static byte[] Xor(byte[] p1, byte[] p2)
+        {
+            if (p1.Length != p2.Length)
+            {
+                Globs.Throw<ArgumentException>("XorEngine: Mismatched arguments length");
+                return new byte[0];
+            }
+            var res = new byte[p1.Length];
+            for (int j = 0; j < p1.Length; j++)
+            {
+                res[j] = (byte)(p1[j] ^ p2[j]);
+            }
+            return res;
+        }
+
+        /// <summary>
+        /// XOR but arrays can be different length (output is lenghth of the shortest input)
+        /// </summary>
+        /// <param name="p1"></param>
+        /// <param name="p2"></param>
+        /// <returns></returns>
+        public static byte[] XorPartial(byte[] p1, byte[] p2)
+        {
+            int len = Math.Min(p1.Length, p2.Length);
+            var res = new byte[len];
+            for (int j = 0; j < len; j++)
+            {
+                res[j] = (byte)(p1[j] ^ p2[j]);
+            }
+            return res;
+        }
+
+        public static byte[] Xor(byte[] data, TpmAlgId hashAlg, byte[] key,
+                                 byte[] contextU, byte[] contextV)
+        {
+            byte[] mask = KDF.KDFa(hashAlg, key, "XOR", contextU, contextV, data.Length * 8);
+            byte[] encData = Xor(mask, data);
+            return encData;
+        }
+    }
+
+    public class KDF
+    {
+        // ReSharper disable once InconsistentNaming
+        public static byte[] KDFa(TpmAlgId hmacHash, byte[] hmacKey, string label,
+                                  byte[] contextU, byte[] contextV, int numBitsRequired) 
+        {
+            int bitsPerLoop = CryptoLib.DigestSize(hmacHash) * 8;
+            long numLoops = (numBitsRequired + bitsPerLoop - 1) / bitsPerLoop;
+            var kdfStream = new byte[numLoops * bitsPerLoop / 8];
+            for (int j = 0; j < numLoops; j++)
+            {
+                byte[] toHmac = Globs.Concatenate(new[] {
+                    Globs.HostToNet(j + 1),
+                    Encoding.UTF8.GetBytes(label), Globs.HostToNet((byte)0),
+                    contextU,
+                    contextV,
+                    Globs.HostToNet(numBitsRequired)
+                });
+                byte[] fragment = CryptoLib.Hmac(hmacHash, hmacKey, toHmac);
+                Array.Copy(fragment, 0, kdfStream, j * bitsPerLoop / 8, fragment.Length);
+            }
+            return Globs.ShiftRight(kdfStream, (int)(bitsPerLoop * numLoops - numBitsRequired));
+        }
+
+        /// <summary>
+        /// split inData into two byte arrays.  The length of the arrays needed is given in bits
+        /// </summary>
+        /// <param name="inData"></param>
+        /// <param name="numBits1"></param>
+        /// <param name="a1"></param>
+        /// <param name="numBits2"></param>
+        /// <param name="a2"></param>
+        public static void Split(byte[] inData, int numBits1, out byte[] a1, int numBits2, out byte[] a2)
+        {
+            if (numBits1 % 8 != 0 || numBits2 % 8 != 0)
+            {
+                Globs.Throw<NotImplementedException>("Split: Only byte-sized chunks are supported");
+                a1 = a2 = new byte[0];
+                return;
+            }
+            a1 = new byte[(numBits1 + 7) / 8];
+            Array.Copy(inData, 0, a1, 0, (numBits1 + 7) / 8);
+            a2 = new byte[(numBits2 + 7) / 8];
+            Array.Copy(inData, (numBits1 + 7) / 8, a2, 0, (numBits2 + 7) / 8);
+        }
+    }
+}

--- a/TSS.NET/TSS.Net.UWP/CryptoSymm.cs
+++ b/TSS.NET/TSS.Net.UWP/CryptoSymm.cs
@@ -1,0 +1,213 @@
+﻿/* 
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Tpm2Lib
+{
+    /// <summary>
+    /// A helper class for doing symmetric cryptography based on 
+    /// TPM structure definitions.
+    /// </summary>
+    public sealed class SymCipher : IDisposable
+    {
+        public bool LimitedSupport = false;
+
+        private BCryptKey Key;
+        private byte[] KeyBuffer;
+        private byte[] IV;
+
+        private SymCipher(BCryptKey key, byte[] keyData, byte[] iv, int blockSize)
+        {
+            Key = key;
+            KeyBuffer = keyData;
+            IV = Globs.CopyData(iv) ?? new byte[BlockSize];
+            BlockSize = blockSize;
+        }
+
+        public byte[] KeyData { get { return KeyBuffer; } }
+
+        public int BlockSize = 0;
+
+        public int IVSize = 16;
+
+        /// <summary>
+        /// Block size in bytes.
+        /// </summary>
+        public static implicit operator byte[] (SymCipher sym)
+        {
+            return sym == null ? null : sym.KeyData;
+        }
+
+        public static int GetBlockSize(SymDefObject symDef)
+        {
+            if (symDef.Algorithm == TpmAlgId.Tdes)
+            {
+                return 8;
+            }
+            if (symDef.Algorithm != TpmAlgId.Aes)
+            {
+                Globs.Throw<ArgumentException>("Unsupported algorithm " + symDef.Algorithm);
+                return 0;
+            }
+            return 16;
+        }
+
+        /// <summary>
+        /// Create a new SymCipher object with a random key based on the alg and mode supplied.
+        /// </summary>
+        /// <param name="symDef"></param>
+        /// <param name="keyData"></param>
+        /// <param name="iv"></param>
+        /// <returns></returns>
+        public static SymCipher Create(SymDefObject symDef = null,
+                                       byte[] keyData = null, byte[] iv = null)
+        {
+            if (symDef == null)
+            {
+                symDef = new SymDefObject(TpmAlgId.Aes, 128, TpmAlgId.Cfb);
+            }
+
+            BCryptAlgorithm alg = null;
+
+            switch (symDef.Algorithm)
+            {
+                case TpmAlgId.Aes:
+                    alg = new BCryptAlgorithm(Native.BCRYPT_AES_ALGORITHM);
+                    break;
+                case TpmAlgId.Tdes:
+                    alg = new BCryptAlgorithm(Native.BCRYPT_3DES_ALGORITHM);
+                    break;
+                default:
+                    Globs.Throw<ArgumentException>("Unsupported symmetric algorithm "
+                                                   + symDef.Algorithm);
+                    return null;
+            }
+
+            if (keyData == null)
+            {
+                keyData = Globs.GetRandomBytes(symDef.KeyBits / 8);
+            }
+            var key = alg.GenerateSymKey(symDef, keyData, GetBlockSize(symDef));
+            //key = BCryptInterface.ExportSymKey(keyHandle);
+            //keyHandle = alg.LoadSymKey(key, symDef, GetBlockSize(symDef));
+            alg.Close();
+            return key == null ? null : new SymCipher(key, keyData, iv, GetBlockSize(symDef));
+        } // Create()
+
+        public static SymCipher CreateFromPublicParms(IPublicParmsUnion parms)
+        {
+            switch (parms.GetUnionSelector())
+            {
+                case TpmAlgId.Rsa:
+                    return Create((parms as RsaParms).symmetric);
+                case TpmAlgId.Ecc:
+                    return Create((parms as EccParms).symmetric);
+                default:
+                    Globs.Throw<ArgumentException>("CreateFromPublicParms: Unsupported algorithm");
+                    return null;
+            }
+        }
+
+        public static byte[] Encrypt(SymDefObject symDef, byte[] key, byte[] iv,
+                                     byte[] dataToEncrypt)
+        {
+            using (SymCipher cipher = Create(symDef, key, iv))
+            {
+                return cipher.Encrypt(dataToEncrypt);
+            }
+        }
+
+        public static byte[] Decrypt(SymDefObject symDef, byte[] key, byte[] iv,
+                                     byte[] dataToDecrypt)
+        {
+            using (SymCipher cipher = Create(symDef, key, iv))
+            {
+                return cipher.Decrypt(dataToDecrypt);
+            }
+        }
+
+        /// <summary>
+        /// Performs the TPM-defined CFB encrypt using the associated algorithm.
+        /// This routine assumes that the integrity value has been prepended.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <param name="iv"></param>
+        /// <returns></returns>
+        public byte[] Encrypt(byte[] data, byte[] iv = null)
+        {
+            byte[] paddedData;
+            int unpadded = data.Length % BlockSize;
+            paddedData = unpadded == 0 ? data : Globs.AddZeroToEnd(data, BlockSize - unpadded);
+            paddedData = Key.Encrypt(paddedData, null, iv ?? IV);
+            return unpadded == 0 ? paddedData : Globs.CopyData(paddedData, 0, data.Length);
+        }
+
+        public byte[] Decrypt(byte[] data, byte[] iv = null)
+        {
+            byte[] paddedData;
+            int unpadded = data.Length % BlockSize;
+            paddedData = unpadded == 0 ? data : Globs.AddZeroToEnd(data, BlockSize - unpadded);
+            paddedData = Key.Decrypt(paddedData, null, iv ?? IV);
+            return Globs.CopyData(paddedData, 0, data.Length);
+        }
+
+        /// <summary>
+        /// De-envelope inner-wrapped duplication blob.
+        /// TODO: Move this to TpmPublic and make it fully general
+        /// </summary>
+        /// <param name="exportedPrivate"></param>
+        /// <param name="encAlg"></param>
+        /// <param name="encKey"></param>
+        /// <param name="nameAlg"></param>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public static Sensitive SensitiveFromDupBlob(TpmPrivate exportedPrivate,
+                                                     SymDefObject encAlg, byte[] encKey,
+                                                     TpmAlgId nameAlg, byte[] name)
+        {
+            byte[] dupBlob = exportedPrivate.buffer;
+            byte[] sensNoLen = null;
+            using (SymCipher c = Create(encAlg, encKey))
+            {
+                byte[] innerObject = null;
+                if (c == null)
+                {
+                    if (encAlg.Algorithm != TpmAlgId.Null)
+                        return null;
+                    else
+                        return Marshaller.FromTpmRepresentation<Sensitive>(Marshaller.Tpm2BToBuffer(dupBlob));
+                }
+                innerObject = c.Decrypt(dupBlob);
+
+                byte[] innerIntegrity, sensitive;
+                KDF.Split(innerObject,
+                          16 + CryptoLib.DigestSize(nameAlg) * 8,
+                          out innerIntegrity,
+                          8 * (innerObject.Length - CryptoLib.DigestSize(nameAlg) - 2),
+                          out sensitive);
+
+                byte[] expectedInnerIntegrity = Marshaller.ToTpm2B(
+                                        CryptoLib.HashData(nameAlg, sensitive, name));
+
+                if (!Globs.ArraysAreEqual(expectedInnerIntegrity, innerIntegrity))
+                {
+                    Globs.Throw("SensitiveFromDupBlob: Bad inner integrity");
+                }
+
+                sensNoLen = Marshaller.Tpm2BToBuffer(sensitive);
+            }
+            var sens = Marshaller.FromTpmRepresentation<Sensitive>(sensNoLen);
+            return sens;
+        }
+
+        public void Dispose()
+        {
+            Key.Dispose();
+        }
+    }
+}

--- a/TSS.NET/TSS.Net.UWP/SupportClasses.cs
+++ b/TSS.NET/TSS.Net.UWP/SupportClasses.cs
@@ -1,0 +1,491 @@
+﻿/* 
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Text;
+
+namespace Tpm2Lib
+{
+    public class ByteBuf
+    {
+        private const int DefaultSize = 1024;
+        private int PutPos;
+        private int GetPos;
+        private byte[] Buf;
+
+        public ByteBuf()
+        {
+            Buf = new byte[DefaultSize];
+            PutPos = 0;
+            GetPos = 0;
+        }
+
+        public ByteBuf(int size)
+        {
+            Buf = new byte[size];
+            PutPos = 0;
+            GetPos = 0;
+        }
+
+        public ByteBuf(byte[] x)
+        {
+            Buf = x;
+            GetPos = 0;
+            PutPos = x.Length;
+        }
+
+        public ByteBuf Clone()
+        {
+            var newBuf = new ByteBuf(GetBuffer());
+            newBuf.GetPos = GetPos;
+            newBuf.PutPos = PutPos;
+            return newBuf;
+        }
+
+        public int BytesRemaining()
+        {
+            return PutPos - GetPos;
+        }
+
+        public void Append(byte[] x)
+        {
+            if (PutPos + x.Length > Buf.Length)
+            {
+                // Extend the array
+                int newLen = Buf.Length * 2;
+                if (newLen < PutPos + x.Length)
+                {
+                    // Big input hack
+                    newLen = (PutPos + x.Length) + 1024;
+                }
+                var buf2 = new byte[newLen];
+                Array.Copy(Buf, buf2, Buf.Length);
+                Buf = buf2;
+            }
+            Array.Copy(x, 0, Buf, PutPos, x.Length);
+            PutPos += x.Length;
+        }
+
+        public byte[] GetBuffer()
+        {
+            var temp = new byte[PutPos];
+            Array.Copy(Buf, temp, PutPos);
+            return temp;
+        }
+
+        public void SetBytesInMiddle(byte[] bytesToSet, int pos)
+        {
+            if (pos + bytesToSet.Length > GetSize())
+            {
+                Globs.Throw<ArgumentOutOfRangeException>("Position is not in allocated buffer");
+                if (GetSize() > pos)
+                    Array.Copy(bytesToSet, 0, Buf, pos, GetSize() - pos);
+                return;
+            }
+            Array.Copy(bytesToSet, 0, Buf, pos, bytesToSet.Length);
+        }
+
+        public byte[] GetBytesInMiddle(int startPos, int length)
+        {
+            var temp = new byte[length];
+            Array.Copy(Buf, startPos, temp, 0, length);
+            return temp;
+        }
+
+        public byte[] RemoveBytesInMiddle(int startPos, int length)
+        {
+            byte[] res = GetBytesInMiddle(startPos, length);
+            // Close the gap
+            for (int j = startPos; j < PutPos - length; j++)
+            {
+                Buf[j] = Buf[j + length];
+            }
+            PutPos -= length;
+            return res;
+        }
+
+        public void Reset()
+        {
+            PutPos = 0;
+            GetPos = 0;
+        }
+
+        public int GetSize()
+        {
+            return PutPos;
+        }
+
+        public int GetGetPos()
+        {
+            return GetPos;
+        }
+
+        public void SetGetPos(int newGetPos)
+        {
+            if (newGetPos < 0 || newGetPos > GetSize())
+            {
+                Globs.Throw("SetGetPos: Invalid position");
+                GetPos = newGetPos < 0 ? 0 : GetSize();
+                return;
+            }
+            GetPos = newGetPos;
+        }
+
+        public byte[] Extract(int num)
+        {
+            if (GetPos + num > PutPos)
+            {
+                Globs.Throw<ArgumentOutOfRangeException>("ByteBuf exception removing "
+                    + num + " bytes at position " + GetPos + " from an array of " + PutPos);
+                return null;
+            }
+            var ret = new byte[num];
+            Array.Copy(Buf, GetPos, ret, 0, num);
+            GetPos += num;
+            return ret;
+        }
+    }
+
+    /// <summary>
+    /// provide implementation of a pseudo-RNG used by all TSS.Net facilities. 
+    /// </summary>
+    public class PRNG
+    {
+        public const int RandMaxBytes = 1024 * 1024;
+
+        /// <summary>
+        /// PRNG seed for the  for this run.  Can be set by SetRngSeed() or from
+        /// the standard system RNG.
+        /// </summary>
+        private byte[] Seed;
+
+        /// <summary>
+        /// A buffer of random data that is emptied on calls to GetRandom() and filled
+        /// when the buffer is empty through FillRandBuf().
+        /// </summary>
+        private ByteBuf Buf = new ByteBuf();
+
+        /// <summary>
+        /// Counter for each round of buffer filling.
+        /// </summary>
+        private int Round;
+
+        /// <summary>
+        /// Creates a copy of the current object
+        /// </summary>
+        public PRNG Clone()
+        {
+            var prng = new PRNG();
+            lock (this)
+            {
+                prng.Seed = Globs.CopyData(Seed);
+                prng.Buf = Buf.Clone();
+                prng.Round = Round;
+            }
+            return prng;
+        }
+
+        /// <summary>
+        /// Set the PRNG seed. If this routine is not called then the seed is generated
+        /// by the system RNG. Note that there is one RNG shared by all threads using
+        /// TPM library services, so non-determinism is to be expected in multi-threaded
+        /// programs even when the RNG is seeded.
+        /// </summary>
+        public void SetRngSeed(string seed)
+        {
+            lock (this)
+            {
+                Seed = seed == null ? new byte[0]
+                                    : CryptoLib.HashData(TpmAlgId.Sha256,
+                                                         Encoding.UTF8.GetBytes(seed));
+                Round = 0;
+                FillRandBuf();
+            }
+        }
+
+        /// <summary>
+        /// Set the tester PRNG seed to random value from the system RNG
+        /// </summary>
+        public void SetRngRandomSeed()
+        {
+            lock (this)
+            {
+                if (Seed != null)
+                    return;
+                Seed = new byte[32];
+                var rnd = new Random();
+                rnd.NextBytes(Seed);
+                Round = 0;
+                FillRandBuf();
+            }
+        }
+
+        /// <summary>
+        /// Retrives the requested number of pseudo-random bytes from the internal pool,
+        /// and replenishes it, if necessary.
+        /// </summary>
+        public byte[] GetRandomBytes(int numBytes)
+        {
+            if (numBytes > RandMaxBytes)
+            {
+                Globs.Throw<ArgumentException>("GetRandomBytes: Too many bytes requested " + numBytes);
+                numBytes = RandMaxBytes;
+            }
+            // Make sure that the RNG is properly seeded
+            if (Seed == null)
+            {
+                SetRngRandomSeed();
+            }
+            // Fill or refill the buffer
+            lock (this)
+            {
+                    // ReSharper disable once PossibleNullReferenceException
+                if (Buf.BytesRemaining() < numBytes)
+                {
+                    FillRandBuf();
+                }
+                // And return the data
+                return Buf.Extract(numBytes);
+            }
+        }
+
+        private void FillRandBuf()
+        {
+            // Fill the buffer with random data
+            byte[] data = KDF.KDFa(TpmAlgId.Sha256, Seed, "RNG",
+                                   BitConverter.GetBytes(Round),
+                                   new byte[0], RandMaxBytes * 8);
+            Round++;
+            Buf = new ByteBuf(data);
+        }
+    } // PRNG
+
+    /// <summary>
+    /// Provides formatting for structures and other TPM types.
+    /// </summary>
+    internal class TpmStructPrinter
+    {
+        private StringBuilder B;
+
+        /// <summary>
+        /// Current printing indent
+        /// </summary>
+        private int Indent;
+
+        internal TpmStructPrinter()
+        {
+            B = new StringBuilder();
+            Indent = 0;
+        }
+
+        public override String ToString()
+        {
+            // Do some final formatting (change ^ for tab)
+            int firstCharInLine = 0;
+            int numSpacesAtStart = 0;
+            bool inStartSpaces = true;
+            int tabNum = 0;
+
+            for (int j = 0; j < B.Length; j++)
+            {
+                if (B[j] == '\n')
+                {
+                    firstCharInLine = j;
+                    inStartSpaces = true;
+                    tabNum = 0;
+                    numSpacesAtStart = 0;
+                    continue;
+                }
+                if (inStartSpaces && B[j] != ' ')
+                {
+                    inStartSpaces = false;
+                    firstCharInLine = j;
+                    numSpacesAtStart++;
+                }
+                if (B[j] == '^')
+                {
+                    tabNum++;
+                    int tabPos = numSpacesAtStart + 0 + tabNum * 16;
+                    int currentColumn = j - firstCharInLine;
+                    string toInsert = " "; // At least one space
+                    if (currentColumn < tabPos)
+                    {
+                        toInsert = new string(' ', tabPos - currentColumn);
+                    }
+                    B = B.Replace("^", toInsert, j, 1);
+                }
+            }
+            return B.ToString();
+        }
+
+        internal void PrintName(string name)
+        {
+            B.AppendFormat("{0}\n", name);
+            Indent++;
+        }
+
+        private void AddLine(StringBuilder b, string formatString, params string[] data)
+        {
+            const int firstTab = 24;
+            const int secondTab = 50;
+            // Coding
+            //   @ - first tab
+            //   # - second tab
+            // We always add indent spaces
+
+            // ReSharper disable once RedundantAssignment
+            String s = formatString = Spaces() + formatString;
+
+            // Is anything too big to fit?
+            if (data[1].Length > secondTab - firstTab)
+            {
+                string dd = data[1];
+                if (dd.Contains('|'))
+                {
+                    // Split enum OR onto multiple lines
+                    dd = dd.Replace("|", "|\n" + new String(' ', firstTab + 1));
+                }
+                if (dd.Contains(".."))
+                {
+                    // Split hex array
+                    dd = dd.Replace("..", "..\n" + new String(' ', firstTab + 2));
+                }
+                data[1] = dd;
+
+            }
+
+            // Fill it in
+            // ReSharper disable once CoVariantArrayConversion
+            s = String.Format(s, data);
+
+            // Set the tabs
+            string outS = "";
+            int column = 0;
+            foreach (char c in s)
+            {
+                if (c == '\n')
+                {
+                    column = -1;
+                }
+                if (c == '@')
+                {
+                    int numSpaces = firstTab - column;
+                    if (numSpaces <= 0)
+                    {
+                        numSpaces = 1;
+                    }
+                    outS += new String(' ', numSpaces);
+                    column += numSpaces;
+                    continue;
+                }
+                if (c == '#')
+                {
+                    int numSpaces = secondTab - column;
+                    if (numSpaces <= 0)
+                    {
+                        numSpaces = 1;
+                    }
+                    outS += new String(' ', numSpaces);
+                    column += numSpaces;
+                    continue;
+                }
+                outS += c;
+                column++;
+            }
+            outS += "\n";
+            b.Append(outS);
+        }
+
+        internal void Print(string name, string type, Object o)
+        {
+            if (o == null)
+            {
+                // E.g. inPrivate null SomeStruct
+                AddLine(B, "{0}@{1}#{2}", name, "null", type);
+                return;
+            }
+
+            // ReSharper disable once CanBeReplacedWithTryCastAndCheckForNull
+            if (o is TpmStructureBase)
+            {
+                string ss = type;
+                if (ss.StartsWith("I"))
+                {
+                    // If the member is an interface, also print the type of entity being dumped
+                    string intType = o.GetType().ToString();
+                    intType = intType.Substring(intType.LastIndexOf('.') + 1);
+
+                    type = intType;
+                }
+                // Print name and type but not the contents (printed recursively later)
+                AddLine(B, "{0}@-#{1}", name, type);
+                // Recurse
+                Indent++;
+                ((TpmStructureBase)o).ToStringInternal(this);
+                Indent--;
+                return;
+            }
+
+            // ReSharper disable once CanBeReplacedWithTryCastAndCheckForNull
+            if (o is Enum)
+            {
+                var en = (Enum)o;
+                string s = Enum.Format(en.GetType(), en, "g");
+                s = s.Replace(',', '|');
+                // name   Elem1|Elem2
+                AddLine(B, "{0}@{1}#{2}", name, s, type);
+                return;
+            }
+
+            if (o is ValueType)
+            {
+                //checked that this actually works with Int64, etc.
+                var val = o is UInt64 ? (Int64)Convert.ToUInt64(o) : Convert.ToInt64(o);
+
+                string hexString = Convert.ToString(val, 16);
+
+                // ReSharper disable once SpecifyACultureInStringConversionExplicitly
+                AddLine(B, "{0}@{1} (0x{2})#{3}", name, o.ToString(), hexString, type);
+                return;
+            }
+
+            // ReSharper disable once CanBeReplacedWithTryCastAndCheckForNull
+            if (o is Array)
+            {
+                var a = (Array)o;
+                Type elementType = o.GetType().GetElementType();
+                if (elementType == typeof (byte))
+                {
+                    // Byte arrays as special - 
+                    string hexString = "0x" + Globs.HexFromByteArray((byte[])a, 8);
+                    string typeString = String.Format("byte[{0}]", a.Length);
+                    AddLine(B, "{0}@{1}#{2}", name, hexString, typeString);
+                    return;
+                }
+                // ReSharper disable once RedundantIfElseBlock
+                else
+                {
+                    B.AppendFormat("{0}Array - {1}[{2}]\n", Spaces(), type, a.Length);
+                    Indent++;
+                    for (int j = 0; j < a.Length; j++)
+                    {
+                        Object elem = a.GetValue(j);
+                        // ReSharper disable once SpecifyACultureInStringConversionExplicitly
+                        Print(elem.GetType().ToString(), j.ToString(), elem);
+                    }
+                    Indent--;
+                    return;
+                }
+            }
+            Globs.Throw<NotImplementedException>("Print: Unknown type " + o.GetType());
+        }
+
+        private string Spaces()
+        {
+            return new String(' ', Indent * 2);
+        }
+    }
+}

--- a/TSS.NET/TSS.Net.UWP/TSS.Net.UWP.csproj
+++ b/TSS.NET/TSS.Net.UWP/TSS.Net.UWP.csproj
@@ -106,6 +106,10 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CryptoAsym.cs" />
+    <Compile Include="CryptoLib.cs" />
+    <Compile Include="CryptoSymm.cs" />
+    <Compile Include="SupportClasses.cs" />
     <Compile Include="..\TSS.Net\CustomExceptions.cs" />
     <Compile Include="..\TSS.Net\GlobalSuppressions.cs" />
     <Compile Include="..\TSS.Net\Globs.cs" />

--- a/TSS.NET/TSS.Net.UWP/TSS.Net.UWP.csproj
+++ b/TSS.NET/TSS.Net.UWP/TSS.Net.UWP.csproj
@@ -106,9 +106,6 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\TSS.Net\CryptoAsym.cs" />
-    <Compile Include="..\TSS.Net\CryptoLib.cs" />
-    <Compile Include="..\TSS.Net\CryptoSymm.cs" />
     <Compile Include="..\TSS.Net\CustomExceptions.cs" />
     <Compile Include="..\TSS.Net\GlobalSuppressions.cs" />
     <Compile Include="..\TSS.Net\Globs.cs" />
@@ -120,7 +117,6 @@
     <Compile Include="..\TSS.Net\Sessions.cs" />
     <Compile Include="..\TSS.Net\SlotContext.cs" />
     <Compile Include="..\TSS.Net\SlotManager.cs" />
-    <Compile Include="..\TSS.Net\SupportClasses.cs" />
     <Compile Include="..\TSS.Net\TbsDevice.cs" />
     <Compile Include="..\TSS.Net\Tpm2.cs" />
     <Compile Include="..\TSS.Net\Tpm2Abstractions.cs" />

--- a/TSS.NET/TSS.Net.UWP/TSS.Net.UWP.csproj
+++ b/TSS.NET/TSS.Net.UWP/TSS.Net.UWP.csproj
@@ -106,6 +106,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="BCryptInterface.cs" />
     <Compile Include="CryptoAsym.cs" />
     <Compile Include="CryptoLib.cs" />
     <Compile Include="CryptoSymm.cs" />

--- a/TSS.NET/TSS.Net/CryptoAsym.cs
+++ b/TSS.NET/TSS.Net/CryptoAsym.cs
@@ -886,9 +886,9 @@ namespace Tpm2Lib
         }
 
         static Dictionary<EccCurve, ECCurve> EccCurves = new Dictionary<EccCurve, ECCurve>() {
-                            {EccCurve.NistP256, ECCurve.CreateFromOid(new Oid("1.2.840.10045.3.1.7" /* NISTP256 */))},
-                            {EccCurve.NistP384, ECCurve.CreateFromOid(new Oid("1.3.132.0.34" /* NISTP384 */))},
-                            {EccCurve.NistP521, ECCurve.CreateFromOid(new Oid("1.3.132.0.35" /* NISTP521 */))},
+                            {EccCurve.NistP256, ECCurve.CreateFromFriendlyName("nistP256")},
+                            {EccCurve.NistP384, ECCurve.CreateFromFriendlyName("nistP384")},
+                            {EccCurve.NistP521, ECCurve.CreateFromFriendlyName("nistP521")},
                         };
 
         internal static ECCurve GetEccCurve(EccCurve curveID)
@@ -896,7 +896,7 @@ namespace Tpm2Lib
             if (!IsCurveSupported(curveID))
             {
                 Globs.Throw<ArgumentException>("Unsupported ECC curve");
-                return ECCurve.CreateFromOid(new Oid("1.2.840.10045.3.1.7" /* NISTP256 */));
+                return ECCurve.CreateFromFriendlyName("nistP256");
             }
             ECCurve curve;
             EccCurves.TryGetValue(curveID, out curve);

--- a/TSS.NET/TSS.Net/TSS.Net.csproj
+++ b/TSS.NET/TSS.Net/TSS.Net.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>TSS.Net</AssemblyName>
-    <TargetFrameworks>netstandard2.1;net472;net48;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <PackageId>TSS.Net</PackageId>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/Tpm2Tester/TestSuite/TestSuite.csproj
+++ b/Tpm2Tester/TestSuite/TestSuite.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.6" />
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.8" />
     <ProjectReference Include="..\..\TSS.NET\TSS.Net\TSS.Net.csproj" />
     <ProjectReference Include="..\TestSubstrate\TestSubstrate.csproj" />
   </ItemGroup>

--- a/Tpm2Tester/TpmProxy/TpmProxy.csproj
+++ b/Tpm2Tester/TpmProxy/TpmProxy.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto, Version=1.8.3.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
-      <HintPath>..\packages\BouncyCastle.1.8.3.1\lib\BouncyCastle.Crypto.dll</HintPath>
-    </Reference>
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.8" />
     <ProjectReference Include="..\..\TSS.NET\TSS.Net\TSS.Net.csproj" />
     <ProjectReference Include="..\TestSubstrate\TestSubstrate.csproj" />
   </ItemGroup>


### PR DESCRIPTION
UWP targets a .NET SDK that doesn't have much cryptography support. This change reintroduces the BCrypt shims that were present for the whole of TSS.Net, just for TSS.Net.UWP.

This change also retargets TSS.NET to only .NET Core 2.1, and Framework 4.7.2. As was mentioned in https://github.com/microsoft/TSS.MSR/issues/101, it's not really necessary to target more than one version of .NET Core, and we should instead target the least common denominator (which for .NET Core for users of VS2017, is 2.1) and allow apps compiled based on this library to target whichever actual runtime version they want (e.g., .NET 5, which has actual runtime support for all these cryptographic providers in Linux, where they just fail at runtime in earlier Core versions).

This change unifies all the BouncyCastle references for TSS.NET together to 1.8.8.

This change switches to referencing the NIST ECC curves by friendly name instead of by OID, which fails at runtime on .NET Framework 4.7.2 on Win10.

Tested: A large, private suite of 250 TPM tests using `dotnet run` against the [reference simulator](https://github.com/microsoft/ms-tpm-20-ref):
- Linux/net5
- Windows/net5
- Windows/framework472

Tested: The whole TSS.MSR solution including the UWP project builds on VS2017 on Windows 10